### PR TITLE
[.NET][Services][Connector][EdgeRegistry] Report connector schemas through Edge Registry

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Connector/ConnectorEdgeRegistryMessageSchema.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/ConnectorEdgeRegistryMessageSchema.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Iot.Operations.Services.EdgeRegistry;
+using Azure.Iot.Operations.Services.EdgeRegistry.Models;
+
+namespace Azure.Iot.Operations.Connector
+{
+    /// <summary>
+    /// A message schema to register with the Edge Registry as a Schema Version.
+    /// </summary>
+    public class ConnectorEdgeRegistryMessageSchema
+    {
+        /// <summary>
+        /// The Schema Group to store the schema under.
+        /// </summary>
+        public GroupId GroupId { get; }
+
+        /// <summary>
+        /// The Schema to store the Version under. Use <see cref="ResourceId.Derive"/> to turn an
+        /// arbitrary identifier into a valid Resource identifier.
+        /// </summary>
+        public string SchemaId { get; }
+
+        /// <summary>
+        /// Queryable key/value pairs to add to the parent Schema.
+        /// </summary>
+        public IReadOnlyList<Label> SchemaLabels { get; }
+
+        /// <summary>
+        /// The attributes of the Schema Version to create.
+        /// </summary>
+        public SchemaVersionAttributes Version { get; }
+
+        public ConnectorEdgeRegistryMessageSchema(
+            string schemaId,
+            SchemaVersionAttributes version,
+            IReadOnlyList<Label>? schemaLabels = null,
+            GroupId groupId = default)
+        {
+            SchemaId = schemaId;
+            Version = version;
+            SchemaLabels = schemaLabels ?? [];
+            GroupId = groupId;
+        }
+
+        /// <summary>
+        /// Builds the identifier that uniquely describes the schema of a dataset. Pass it through
+        /// <see cref="ResourceId.Derive"/> to turn it into a valid Resource identifier.
+        /// </summary>
+        public static string DefaultDatasetSchemaId(string deviceName, string inboundEndpointName, string assetName, string datasetName)
+            => $"{deviceName}:{inboundEndpointName}:{assetName}:dataset:{datasetName}";
+
+        /// <summary>
+        /// Builds the identifier that uniquely describes the schema of an event. Pass it through
+        /// <see cref="ResourceId.Derive"/> to turn it into a valid Resource identifier.
+        /// </summary>
+        public static string DefaultEventSchemaId(string deviceName, string inboundEndpointName, string assetName, string eventGroupName, string eventName)
+            => $"{deviceName}:{inboundEndpointName}:{assetName}:event:{eventGroupName}:{eventName}";
+    }
+}

--- a/dotnet/src/Azure.Iot.Operations.Connector/ConnectorWorker.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/ConnectorWorker.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Text;
 using Azure.Iot.Operations.Connector.CloudEvents;
 using Azure.Iot.Operations.Connector.ConnectorConfigurations;
@@ -11,6 +12,8 @@ using Azure.Iot.Operations.Protocol.Connection;
 using Azure.Iot.Operations.Protocol.Models;
 using Azure.Iot.Operations.Protocol.Telemetry;
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
+using Azure.Iot.Operations.Services.EdgeRegistry;
+using Azure.Iot.Operations.Services.EdgeRegistry.Models;
 using Azure.Iot.Operations.Services.LeaderElection;
 using Azure.Iot.Operations.Services.SchemaRegistry;
 using Azure.Iot.Operations.Services.SchemaRegistry.SchemaRegistry;
@@ -29,6 +32,7 @@ namespace Azure.Iot.Operations.Connector
         private readonly IAzureDeviceRegistryClientWrapperProvider _adrClientWrapperFactory;
         protected IAzureDeviceRegistryClientWrapper? _adrClient;
         private readonly IMessageSchemaProvider _messageSchemaProviderFactory;
+        private readonly IEdgeRegistryMessageSchemaProvider? _edgeRegistryMessageSchemaProvider;
         private LeaderElectionClient? _leaderElectionClient;
         private readonly ConcurrentDictionary<string, DeviceContext> _devices = new();
 
@@ -54,10 +58,10 @@ namespace Azure.Iot.Operations.Connector
         private readonly object _deviceNotificationChainLock = new();
 
         // keys are "{composite device name}_{asset name}_{dataset name}. The value is the message schema registered for that device's asset's dataset
-        private readonly ConcurrentDictionary<string, Schema> _registeredDatasetMessageSchemas = new();
+        private readonly ConcurrentDictionary<string, MessageSchemaReference> _registeredDatasetMessageSchemas = new();
 
         // keys are "{composite device name}_{asset name}_{event group name}_{event name}. The value is the message schema registered for that device's asset's event
-        private readonly ConcurrentDictionary<string, Schema> _registeredEventMessageSchemas = new();
+        private readonly ConcurrentDictionary<string, MessageSchemaReference> _registeredEventMessageSchemas = new();
 
         /// <summary>
         /// Event handler for when a device becomes available.
@@ -108,12 +112,14 @@ namespace Azure.Iot.Operations.Connector
             IMessageSchemaProvider messageSchemaProviderFactory,
             IAzureDeviceRegistryClientWrapperProvider adrClientWrapperFactory,
             IConnectorLeaderElectionConfigurationProvider? leaderElectionConfigurationProvider = null,
-            IManagementActionHandlerFactory? actionHandlerFactory = null)
+            IManagementActionHandlerFactory? actionHandlerFactory = null,
+            IEdgeRegistryMessageSchemaProvider? edgeRegistryMessageSchemaProvider = null)
         {
             ApplicationContext = applicationContext;
             _logger = logger;
             _mqttClient = mqttClient;
             _messageSchemaProviderFactory = messageSchemaProviderFactory;
+            _edgeRegistryMessageSchemaProvider = edgeRegistryMessageSchemaProvider;
             _adrClientWrapperFactory = adrClientWrapperFactory;
             _leaderElectionConfiguration = leaderElectionConfigurationProvider?.GetLeaderElectionConfiguration();
             if (actionHandlerFactory != null)
@@ -311,32 +317,14 @@ namespace Azure.Iot.Operations.Connector
 
         public MessageSchemaReference? GetRegisteredDatasetMessageSchema(string deviceName, string inboundEndpointName, string assetName, string datasetName)
         {
-            if (_registeredDatasetMessageSchemas.TryGetValue($"{deviceName}_{inboundEndpointName}_{assetName}_{datasetName}", out Schema? schema))
-            {
-                return new MessageSchemaReference()
-                {
-                    SchemaName = schema.Name,
-                    SchemaRegistryNamespace = schema.Namespace,
-                    SchemaVersion = schema.Version,
-                };
-            }
-
-            return null;
+            _registeredDatasetMessageSchemas.TryGetValue($"{deviceName}_{inboundEndpointName}_{assetName}_{datasetName}", out MessageSchemaReference? schemaReference);
+            return schemaReference;
         }
 
         public MessageSchemaReference? GetRegisteredEventMessageSchema(string deviceName, string inboundEndpointName, string assetName, string eventGroupName, string eventName)
         {
-            if (_registeredEventMessageSchemas.TryGetValue($"{deviceName}_{inboundEndpointName}_{assetName}_{eventGroupName}_{eventName}", out Schema? schema))
-            {
-                return new MessageSchemaReference()
-                {
-                    SchemaName = schema.Name,
-                    SchemaRegistryNamespace = schema.Namespace,
-                    SchemaVersion = schema.Version,
-                };
-            }
-
-            return null;
+            _registeredEventMessageSchemas.TryGetValue($"{deviceName}_{inboundEndpointName}_{assetName}_{eventGroupName}_{eventName}", out MessageSchemaReference? schemaReference);
+            return schemaReference;
         }
 
         // Called by AssetClient instances
@@ -347,43 +335,21 @@ namespace Azure.Iot.Operations.Connector
             ObjectDisposedException.ThrowIf(_isDisposed, this);
 
             CloudEvents.AioCloudEvent? aioCloudEvent = null;
-            Schema? registeredDatasetMessageSchema = null;
-            if (!_registeredDatasetMessageSchemas.ContainsKey($"{deviceName}_{inboundEndpointName}_{assetName}_{dataset.Name}"))
+            string datasetSchemaKey = $"{deviceName}_{inboundEndpointName}_{assetName}_{dataset.Name}";
+            if (!_registeredDatasetMessageSchemas.ContainsKey(datasetSchemaKey))
             {
-                // This may register a message schema that has already been uploaded, but the schema registry service is idempotent
-                var datasetMessageSchema = await _messageSchemaProviderFactory.GetMessageSchemaAsync(device, asset, dataset.Name!, dataset, cancellationToken);
-                if (datasetMessageSchema != null)
+                // This may register a message schema that has already been uploaded, but the registry service is idempotent
+                MessageSchemaReference? registeredSchemaReference = _edgeRegistryMessageSchemaProvider != null
+                    ? await RegisterEdgeRegistryDatasetMessageSchemaAsync(deviceName, device, inboundEndpointName, assetName, asset, dataset, cancellationToken)
+                    : await RegisterDatasetMessageSchemaAsync(deviceName, device, inboundEndpointName, assetName, asset, dataset, cancellationToken);
+
+                if (registeredSchemaReference != null)
                 {
-                    try
-                    {
-                        _logger.LogInformation($"Registering message schema for dataset with name {dataset.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}");
-                        await using SchemaRegistryClient schemaRegistryClient = new(ApplicationContext, _mqttClient);
-                        registeredDatasetMessageSchema = await schemaRegistryClient.PutAsync(
-                            datasetMessageSchema.SchemaContent,
-                            datasetMessageSchema.SchemaFormat,
-                            datasetMessageSchema.SchemaType,
-                            datasetMessageSchema.Version ?? "1",
-                            datasetMessageSchema.Tags,
-                            cancellationToken: cancellationToken);
-
-                        _logger.LogInformation($"Registered message schema for dataset with name {dataset.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}.");
-
-                        _registeredDatasetMessageSchemas.TryAdd($"{deviceName}_{inboundEndpointName}_{assetName}_{dataset.Name}", registeredDatasetMessageSchema);
-
-                        await schemaRegistryClient.StopAsync(cancellationToken);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError($"Failed to register message schema for dataset with name {dataset.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}. Error: {ex.Message}");
-                    }
-                }
-                else
-                {
-                    _logger.LogInformation($"No message schema will be registered for dataset with name {dataset.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}");
+                    _registeredDatasetMessageSchemas.TryAdd(datasetSchemaKey, registeredSchemaReference);
                 }
             }
 
-            if (_registeredDatasetMessageSchemas.TryGetValue($"{deviceName}_{inboundEndpointName}_{assetName}_{dataset.Name}", out registeredDatasetMessageSchema))
+            if (_registeredDatasetMessageSchemas.TryGetValue(datasetSchemaKey, out MessageSchemaReference? registeredDatasetMessageSchema))
             {
                 aioCloudEvent = ConstructCloudEventHeadersForDataset(
                     device,
@@ -499,44 +465,22 @@ namespace Azure.Iot.Operations.Connector
                 return;
             }
 
-            Schema? registeredEventMessageSchema = null;
-            if (!_registeredEventMessageSchemas.ContainsKey($"{deviceName}_{inboundEndpointName}_{assetName}_{eventGroupName}_{assetEvent.Name}"))
+            string eventSchemaKey = $"{deviceName}_{inboundEndpointName}_{assetName}_{eventGroupName}_{assetEvent.Name}";
+            if (!_registeredEventMessageSchemas.ContainsKey(eventSchemaKey))
             {
-                // This may register a message schema that has already been uploaded, but the schema registry service is idempotent
-                var eventMessageSchema = await _messageSchemaProviderFactory.GetMessageSchemaAsync(device, asset, assetEvent.Name, assetEvent, cancellationToken);
-                if (eventMessageSchema != null)
+                // This may register a message schema that has already been uploaded, but the registry service is idempotent
+                MessageSchemaReference? registeredSchemaReference = _edgeRegistryMessageSchemaProvider != null
+                    ? await RegisterEdgeRegistryEventMessageSchemaAsync(deviceName, device, inboundEndpointName, assetName, asset, eventGroupName, assetEvent, cancellationToken)
+                    : await RegisterEventMessageSchemaAsync(deviceName, device, inboundEndpointName, assetName, asset, eventGroupName, assetEvent, cancellationToken);
+
+                if (registeredSchemaReference != null)
                 {
-                    try
-                    {
-                        _logger.LogInformation($"Registering message schema for event with name {assetEvent.Name} in event group with name {eventGroupName} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}");
-                        await using SchemaRegistryClient schemaRegistryClient = new(ApplicationContext, _mqttClient);
-                        registeredEventMessageSchema = await schemaRegistryClient.PutAsync(
-                            eventMessageSchema.SchemaContent,
-                            eventMessageSchema.SchemaFormat,
-                            eventMessageSchema.SchemaType,
-                            eventMessageSchema.Version ?? "1",
-                            eventMessageSchema.Tags,
-                            cancellationToken: cancellationToken);
-
-                        _logger.LogInformation($"Registered message schema for event with name {assetEvent.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}.");
-
-                        _registeredEventMessageSchemas.TryAdd($"{deviceName}_{inboundEndpointName}_{assetName}_{eventGroupName}_{assetEvent.Name}", registeredEventMessageSchema);
-
-                        await schemaRegistryClient.StopAsync(cancellationToken);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError($"Failed to register message schema for event with name {assetEvent.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}. Error: {ex.Message}");
-                    }
-                }
-                else
-                {
-                    _logger.LogInformation($"No message schema will be registered for event with name {assetEvent.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}");
+                    _registeredEventMessageSchemas.TryAdd(eventSchemaKey, registeredSchemaReference);
                 }
             }
 
             CloudEvents.AioCloudEvent? aioCloudEvent = null;
-            if (_registeredEventMessageSchemas.TryGetValue($"{deviceName}_{inboundEndpointName}_{assetName}_{eventGroupName}_{assetEvent.Name}", out registeredEventMessageSchema))
+            if (_registeredEventMessageSchemas.TryGetValue(eventSchemaKey, out MessageSchemaReference? registeredEventMessageSchema))
             {
                 aioCloudEvent = ConstructCloudEventHeadersForEvent(
                     device,
@@ -1213,24 +1157,170 @@ namespace Azure.Iot.Operations.Connector
             return compoundDeviceName + "_" + assetName;
         }
 
+        private async Task<MessageSchemaReference?> RegisterDatasetMessageSchemaAsync(string deviceName, Device device, string inboundEndpointName, string assetName, Asset asset,
+            AssetDataset dataset, CancellationToken cancellationToken)
+        {
+            ConnectorMessageSchema? datasetMessageSchema = await _messageSchemaProviderFactory.GetMessageSchemaAsync(device, asset, dataset.Name!, dataset, cancellationToken);
+            if (datasetMessageSchema == null)
+            {
+                _logger.LogInformation($"No message schema will be registered for dataset with name {dataset.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}");
+                return null;
+            }
+
+            try
+            {
+                _logger.LogInformation($"Registering message schema for dataset with name {dataset.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}");
+                await using SchemaRegistryClient schemaRegistryClient = new(ApplicationContext, _mqttClient);
+                Schema registeredSchema = await schemaRegistryClient.PutAsync(
+                    datasetMessageSchema.SchemaContent,
+                    datasetMessageSchema.SchemaFormat,
+                    datasetMessageSchema.SchemaType,
+                    datasetMessageSchema.Version ?? "1",
+                    datasetMessageSchema.Tags,
+                    cancellationToken: cancellationToken);
+
+                _logger.LogInformation($"Registered message schema for dataset with name {dataset.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}.");
+
+                await schemaRegistryClient.StopAsync(cancellationToken);
+
+                return ToMessageSchemaReference(registeredSchema);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to register message schema for dataset with name {dataset.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}. Error: {ex.Message}");
+                return null;
+            }
+        }
+
+        private async Task<MessageSchemaReference?> RegisterEdgeRegistryDatasetMessageSchemaAsync(string deviceName, Device device, string inboundEndpointName, string assetName, Asset asset,
+            AssetDataset dataset, CancellationToken cancellationToken)
+        {
+            ConnectorEdgeRegistryMessageSchema? datasetMessageSchema = await _edgeRegistryMessageSchemaProvider!.GetMessageSchemaAsync(deviceName, device, inboundEndpointName, assetName, asset, dataset.Name!, dataset, cancellationToken);
+            if (datasetMessageSchema == null)
+            {
+                _logger.LogInformation($"No message schema will be registered for dataset with name {dataset.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}");
+                return null;
+            }
+
+            try
+            {
+                _logger.LogInformation($"Registering message schema for dataset with name {dataset.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}");
+                await using EdgeRegistryClient edgeRegistryClient = new(ApplicationContext, _mqttClient);
+                SchemaVersion registeredSchemaVersion = await edgeRegistryClient.CreateSchemaVersionAsync(
+                    datasetMessageSchema.GroupId,
+                    datasetMessageSchema.SchemaId,
+                    datasetMessageSchema.SchemaLabels,
+                    datasetMessageSchema.Version,
+                    cancellationToken: cancellationToken);
+
+                _logger.LogInformation($"Registered message schema for dataset with name {dataset.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}.");
+
+                await edgeRegistryClient.StopAsync(cancellationToken);
+
+                return ToMessageSchemaReference(registeredSchemaVersion);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to register message schema for dataset with name {dataset.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}. Error: {ex.Message}");
+                return null;
+            }
+        }
+
+        private async Task<MessageSchemaReference?> RegisterEventMessageSchemaAsync(string deviceName, Device device, string inboundEndpointName, string assetName, Asset asset,
+            string eventGroupName, AssetEvent assetEvent, CancellationToken cancellationToken)
+        {
+            ConnectorMessageSchema? eventMessageSchema = await _messageSchemaProviderFactory.GetMessageSchemaAsync(device, asset, assetEvent.Name, assetEvent, cancellationToken);
+            if (eventMessageSchema == null)
+            {
+                _logger.LogInformation($"No message schema will be registered for event with name {assetEvent.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}");
+                return null;
+            }
+
+            try
+            {
+                _logger.LogInformation($"Registering message schema for event with name {assetEvent.Name} in event group with name {eventGroupName} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}");
+                await using SchemaRegistryClient schemaRegistryClient = new(ApplicationContext, _mqttClient);
+                Schema registeredSchema = await schemaRegistryClient.PutAsync(
+                    eventMessageSchema.SchemaContent,
+                    eventMessageSchema.SchemaFormat,
+                    eventMessageSchema.SchemaType,
+                    eventMessageSchema.Version ?? "1",
+                    eventMessageSchema.Tags,
+                    cancellationToken: cancellationToken);
+
+                _logger.LogInformation($"Registered message schema for event with name {assetEvent.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}.");
+
+                await schemaRegistryClient.StopAsync(cancellationToken);
+
+                return ToMessageSchemaReference(registeredSchema);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to register message schema for event with name {assetEvent.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}. Error: {ex.Message}");
+                return null;
+            }
+        }
+
+        private async Task<MessageSchemaReference?> RegisterEdgeRegistryEventMessageSchemaAsync(string deviceName, Device device, string inboundEndpointName, string assetName, Asset asset,
+            string eventGroupName, AssetEvent assetEvent, CancellationToken cancellationToken)
+        {
+            ConnectorEdgeRegistryMessageSchema? eventMessageSchema = await _edgeRegistryMessageSchemaProvider!.GetMessageSchemaAsync(deviceName, device, inboundEndpointName, assetName, asset, eventGroupName, assetEvent.Name, assetEvent, cancellationToken);
+            if (eventMessageSchema == null)
+            {
+                _logger.LogInformation($"No message schema will be registered for event with name {assetEvent.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}");
+                return null;
+            }
+
+            try
+            {
+                _logger.LogInformation($"Registering message schema for event with name {assetEvent.Name} in event group with name {eventGroupName} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}");
+                await using EdgeRegistryClient edgeRegistryClient = new(ApplicationContext, _mqttClient);
+                SchemaVersion registeredSchemaVersion = await edgeRegistryClient.CreateSchemaVersionAsync(
+                    eventMessageSchema.GroupId,
+                    eventMessageSchema.SchemaId,
+                    eventMessageSchema.SchemaLabels,
+                    eventMessageSchema.Version,
+                    cancellationToken: cancellationToken);
+
+                _logger.LogInformation($"Registered message schema for event with name {assetEvent.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}.");
+
+                await edgeRegistryClient.StopAsync(cancellationToken);
+
+                return ToMessageSchemaReference(registeredSchemaVersion);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to register message schema for event with name {assetEvent.Name} on asset with name {assetName} associated with device with name {deviceName} and inbound endpoint name {inboundEndpointName}. Error: {ex.Message}");
+                return null;
+            }
+        }
+
+        private static MessageSchemaReference ToMessageSchemaReference(Schema registeredSchema) => new()
+        {
+            SchemaName = registeredSchema.Name,
+            SchemaRegistryNamespace = registeredSchema.Namespace,
+            SchemaVersion = registeredSchema.Version,
+        };
+
+        // The Schema Group that owns the Schema Version is only available as part of its XID.
+        private static MessageSchemaReference ToMessageSchemaReference(SchemaVersion registeredSchemaVersion) => new()
+        {
+            SchemaName = registeredSchemaVersion.ResourceId,
+            SchemaRegistryNamespace = VersionXId.Parse(registeredSchemaVersion.XId).GroupId,
+            SchemaVersion = registeredSchemaVersion.VersionId.ToString(CultureInfo.InvariantCulture),
+        };
+
         internal AioCloudEvent? ConstructCloudEventHeadersForDataset(Device device,
             string deviceName,
             string inboundEndpointName,
             Asset asset,
             string assetName,
             AssetDataset dataset,
-            Schema registeredSchema,
+            MessageSchemaReference schemaRef,
             string? protocolSpecificIdentifier = null)
         {
             try
             {
-                var schemaRef = new MessageSchemaReference
-                {
-                    SchemaRegistryNamespace = registeredSchema.Namespace,
-                    SchemaName = registeredSchema.Name,
-                    SchemaVersion = registeredSchema.Version
-                };
-
                 return AioCloudEventBuilder.Build(
                     device,
                     deviceName,
@@ -1255,18 +1345,11 @@ namespace Azure.Iot.Operations.Connector
             string assetName,
             string eventGroupName,
             AssetEvent assetEvent,
-            Schema registeredSchema,
+            MessageSchemaReference schemaRef,
             string? protocolSpecificIdentifier = null)
         {
             try
             {
-                var schemaRef = new MessageSchemaReference
-                {
-                    SchemaRegistryNamespace = registeredSchema.Namespace,
-                    SchemaName = registeredSchema.Name,
-                    SchemaVersion = registeredSchema.Version
-                };
-
                 return AioCloudEventBuilder.Build(
                     device,
                     deviceName,

--- a/dotnet/src/Azure.Iot.Operations.Connector/IEdgeRegistryMessageSchemaProvider.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/IEdgeRegistryMessageSchemaProvider.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
+
+namespace Azure.Iot.Operations.Connector
+{
+    /// <summary>
+    /// The interface for a connector to request message schema information about datasets and/or events
+    /// that is registered with the Edge Registry rather than the Schema Registry.
+    /// </summary>
+    /// <remarks>
+    /// Provide an implementation of this interface instead of <see cref="IMessageSchemaProvider"/> when
+    /// your deployment of AIO has the Edge Registry service. When both are provided, this one wins.
+    /// </remarks>
+    public interface IEdgeRegistryMessageSchemaProvider
+    {
+        /// <summary>
+        /// Get the message schema associated with this dataset. If provided, the connector will register this message schema prior to forwarding any dataset telemetry for this dataset.
+        /// </summary>
+        /// <param name="deviceName">The name of the device this dataset will be sampled from.</param>
+        /// <param name="device">The device this dataset will be sampled from.</param>
+        /// <param name="inboundEndpointName">The name of the inbound endpoint this dataset will be sampled from.</param>
+        /// <param name="assetName">The name of the asset this dataset belongs to.</param>
+        /// <param name="asset">The asset this dataset belongs to.</param>
+        /// <param name="datasetName">The name of the dataset.</param>
+        /// <param name="dataset">The dataset.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The message schema to register for data sampled from this dataset. If null, no message schema will be registered for this dataset.</returns>
+        Task<ConnectorEdgeRegistryMessageSchema?> GetMessageSchemaAsync(string deviceName, Device device, string inboundEndpointName, string assetName, Asset asset, string datasetName, AssetDataset dataset, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get the message schema associated with this event. If provided, the connector will register this message schema prior to forwarding any event telemetry for this event.
+        /// </summary>
+        /// <param name="deviceName">The name of the device this event will be received from.</param>
+        /// <param name="device">The device this event will be received from.</param>
+        /// <param name="inboundEndpointName">The name of the inbound endpoint this event will be received from.</param>
+        /// <param name="assetName">The name of the asset this event belongs to.</param>
+        /// <param name="asset">The asset this event belongs to.</param>
+        /// <param name="eventGroupName">The name of the event group the event belongs to.</param>
+        /// <param name="eventName">The name of the event.</param>
+        /// <param name="assetEvent">The event</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The message schema to register for data received from this event. If null, no message schema will be registered for this event.</returns>
+        Task<ConnectorEdgeRegistryMessageSchema?> GetMessageSchemaAsync(string deviceName, Device device, string inboundEndpointName, string assetName, Asset asset, string eventGroupName, string eventName, AssetEvent assetEvent, CancellationToken cancellationToken = default);
+    }
+}

--- a/dotnet/src/Azure.Iot.Operations.Connector/PollingTelemetryConnectorWorker.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/PollingTelemetryConnectorWorker.cs
@@ -12,7 +12,7 @@ namespace Azure.Iot.Operations.Connector
     {
         private readonly IDatasetSamplerFactory _datasetSamplerFactory;
 
-        public PollingTelemetryConnectorWorker(ApplicationContext applicationContext, ILogger<ConnectorWorker> logger, IMqttClient mqttClient, IDatasetSamplerFactory datasetSamplerFactory, IMessageSchemaProvider messageSchemaFactory, IAzureDeviceRegistryClientWrapperProvider adrClientFactory, IConnectorLeaderElectionConfigurationProvider? leaderElectionConfigurationProvider = null) : base(applicationContext, logger, mqttClient, messageSchemaFactory, adrClientFactory, leaderElectionConfigurationProvider)
+        public PollingTelemetryConnectorWorker(ApplicationContext applicationContext, ILogger<ConnectorWorker> logger, IMqttClient mqttClient, IDatasetSamplerFactory datasetSamplerFactory, IMessageSchemaProvider messageSchemaFactory, IAzureDeviceRegistryClientWrapperProvider adrClientFactory, IConnectorLeaderElectionConfigurationProvider? leaderElectionConfigurationProvider = null, IEdgeRegistryMessageSchemaProvider? edgeRegistryMessageSchemaProvider = null) : base(applicationContext, logger, mqttClient, messageSchemaFactory, adrClientFactory, leaderElectionConfigurationProvider, edgeRegistryMessageSchemaProvider: edgeRegistryMessageSchemaProvider)
         {
             base.WhileDeviceIsAvailable = WhileDeviceAvailableAsync;
             base.WhileAssetIsAvailable = WhileAssetAvailableAsync;

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/Models/VersionXId.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/Models/VersionXId.cs
@@ -8,6 +8,9 @@ namespace Azure.Iot.Operations.Services.EdgeRegistry.Models;
 /// </summary>
 public class VersionXId
 {
+    private const string VersionsSegment = "versions";
+    private const int SegmentCount = 6;
+
     /// <summary>
     /// Group type.
     /// </summary>
@@ -32,4 +35,33 @@ public class VersionXId
     /// Version identifier.
     /// </summary>
     public required string VersionId { get; set; }
+
+    /// <summary>
+    /// Parses a full XID path of the form
+    /// <c>/{groupType}/{groupId}/{resourceType}/{resourceId}/versions/{versionId}</c> into its components.
+    /// </summary>
+    /// <param name="xid">The XID path to parse. A leading <c>/</c> is optional.</param>
+    /// <returns>The parsed components.</returns>
+    /// <exception cref="FormatException"><paramref name="xid"/> isn't a Version XID path.</exception>
+    public static VersionXId Parse(string xid)
+    {
+        ArgumentNullException.ThrowIfNull(xid);
+
+        string[] segments = xid.TrimStart('/').Split('/');
+        if (segments.Length != SegmentCount
+            || segments[4] != VersionsSegment
+            || Array.Exists(segments, segment => segment.Length == 0))
+        {
+            throw new FormatException($"Invalid Version XID format: {xid}");
+        }
+
+        return new VersionXId
+        {
+            GroupType = segments[0],
+            GroupId = segments[1],
+            ResourceType = segments[2],
+            ResourceId = segments[3],
+            VersionId = segments[5],
+        };
+    }
 }

--- a/dotnet/test/Azure.Iot.Operations.Connector.UnitTests/ConnectorEdgeRegistryMessageSchemaTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Connector.UnitTests/ConnectorEdgeRegistryMessageSchemaTests.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace Azure.Iot.Operations.Connector.UnitTests
+{
+    public class ConnectorEdgeRegistryMessageSchemaTests
+    {
+        // Pins the format every SDK must produce, so that connectors in different languages derive the
+        // same Schema identifier for the same data operation.
+        [Fact]
+        public void DefaultDatasetSchemaIdIdentifiesTheDataOperation()
+        {
+            Assert.Equal(
+                "my-device:my-endpoint:my-asset:dataset:my-dataset",
+                ConnectorEdgeRegistryMessageSchema.DefaultDatasetSchemaId("my-device", "my-endpoint", "my-asset", "my-dataset"));
+        }
+
+        [Fact]
+        public void DefaultEventSchemaIdIdentifiesTheDataOperation()
+        {
+            Assert.Equal(
+                "my-device:my-endpoint:my-asset:event:my-event-group:my-event",
+                ConnectorEdgeRegistryMessageSchema.DefaultEventSchemaId("my-device", "my-endpoint", "my-asset", "my-event-group", "my-event"));
+        }
+    }
+}

--- a/dotnet/test/Azure.Iot.Operations.Connector.UnitTests/ConnectorWorkerTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Connector.UnitTests/ConnectorWorkerTests.cs
@@ -50,13 +50,7 @@ namespace Azure.Iot.Operations.Connector.UnitTests
             Device device = CreateTestDevice();
             Asset asset = CreateTestAsset();
             AssetDataset dataset = new AssetDataset { Name = TestDatasetName };
-            Schema schema = new Schema
-            {
-                Name = "test-schema",
-                Version = "1.0.0",
-                Format = Format.JsonSchemaDraft07,
-                SchemaType = SchemaType.MessageSchema,
-            };
+            MessageSchemaReference schema = CreateTestSchemaReference();
 
             MockMqttClient mockMqttClient = new MockMqttClient();
             MockAzureDeviceRegistryClientWrapper mockAdrClientWrapper = new MockAzureDeviceRegistryClientWrapper();
@@ -94,13 +88,7 @@ namespace Azure.Iot.Operations.Connector.UnitTests
             Device device = CreateTestDevice();
             Asset asset = CreateTestAsset();
             AssetDataset dataset = new AssetDataset { Name = TestDatasetName };
-            Schema schema = new Schema
-            {
-                Name = "test-schema",
-                Version = "1.0.0",
-                Format = Format.JsonSchemaDraft07,
-                SchemaType = SchemaType.MessageSchema,
-            };
+            MessageSchemaReference schema = CreateTestSchemaReference();
 
             MockMqttClient mockMqttClient = new MockMqttClient();
             MockAzureDeviceRegistryClientWrapper mockAdrClientWrapper = new MockAzureDeviceRegistryClientWrapper();
@@ -136,13 +124,7 @@ namespace Azure.Iot.Operations.Connector.UnitTests
             // Arrange
             Device device = CreateTestDevice();
             Asset asset = CreateTestAsset();
-            Schema schema = new Schema
-            {
-                Name = "test-schema",
-                Version = "1.0.0",
-                Format = Format.JsonSchemaDraft07,
-                SchemaType = SchemaType.MessageSchema,
-            };
+            MessageSchemaReference schema = CreateTestSchemaReference();
 
             MockMqttClient mockMqttClient = new MockMqttClient();
             MockAzureDeviceRegistryClientWrapper mockAdrClientWrapper = new MockAzureDeviceRegistryClientWrapper();
@@ -181,13 +163,7 @@ namespace Azure.Iot.Operations.Connector.UnitTests
             // Arrange
             Device device = CreateTestDevice();
             Asset asset = CreateTestAsset();
-            Schema schema = new Schema
-            {
-                Name = "test-schema",
-                Version = "1.0.0",
-                Format = Format.JsonSchemaDraft07,
-                SchemaType = SchemaType.MessageSchema,
-            };
+            MessageSchemaReference schema = CreateTestSchemaReference();
 
             MockMqttClient mockMqttClient = new MockMqttClient();
             MockAzureDeviceRegistryClientWrapper mockAdrClientWrapper = new MockAzureDeviceRegistryClientWrapper();
@@ -217,6 +193,16 @@ namespace Azure.Iot.Operations.Connector.UnitTests
             Assert.NotNull(result);
             Assert.NotNull(result.Source);
             Assert.DoesNotContain(TestEndpointAddress, result.Source.ToString());
+        }
+
+        private static MessageSchemaReference CreateTestSchemaReference()
+        {
+            return new MessageSchemaReference()
+            {
+                SchemaName = "test-schema",
+                SchemaRegistryNamespace = "test-namespace",
+                SchemaVersion = "1.0.0",
+            };
         }
 
         private static Device CreateTestDevice()

--- a/dotnet/test/Azure.Iot.Operations.Services.UnitTests/EdgeRegistry/VersionXIdTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Services.UnitTests/EdgeRegistry/VersionXIdTests.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Iot.Operations.Services.EdgeRegistry.Models;
+using Xunit;
+
+namespace Azure.Iot.Operations.Services.UnitTests.EdgeRegistry;
+
+public class VersionXIdTests
+{
+    [Theory]
+    [InlineData("/schemagroups/my-group/schemas/my-schema/versions/1")] // leading slash
+    [InlineData("schemagroups/my-group/schemas/my-schema/versions/1")] // no leading slash
+    public void ParsesAVersionXId(string xid)
+    {
+        VersionXId parsed = VersionXId.Parse(xid);
+
+        Assert.Equal("schemagroups", parsed.GroupType);
+        Assert.Equal("my-group", parsed.GroupId);
+        Assert.Equal("schemas", parsed.ResourceType);
+        Assert.Equal("my-schema", parsed.ResourceId);
+        Assert.Equal("1", parsed.VersionId);
+    }
+
+    [Theory]
+    [InlineData("")] // empty
+    [InlineData("/")] // root
+    [InlineData("/schemagroups/my-group/schemas/my-schema/versions")] // too few segments
+    [InlineData("/schemagroups/my-group/schemas/my-schema/versions/1/2")] // too many segments
+    [InlineData("/schemagroups/my-group/schemas/my-schema/revisions/1")] // missing the versions segment
+    [InlineData("/schemagroups//schemas/my-schema/versions/1")] // empty path segment
+    [InlineData("/schemagroups/my-group/schemas/my-schema/versions/")] // trailing empty segment
+    public void RejectsANonVersionXId(string xid)
+    {
+        Assert.Throws<FormatException>(() => VersionXId.Parse(xid));
+    }
+}


### PR DESCRIPTION
Mirrors Rust #1473. Implementing IEdgeRegistryMessageSchemaProvider makes the connector register message schemas as Edge Registry Schema Versions instead of Schema Registry schemas; either way the reported MessageSchemaReference is what the worker caches and puts on the CloudEvent. VersionXId.Parse recovers the registry namespace from the created Version's XID.