### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/actions/configure-aio/action.yml
+++ b/.github/actions/configure-aio/action.yml
@@ -34,7 +34,7 @@ runs:
       shell: bash
 
     - name: Checkout deploy action
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         repository: azure/iot-operations-sdks-action
         path: action-deploy
@@ -59,19 +59,19 @@ runs:
 
     - name: Setup .NET
       if: inputs.install-dotnet == 'true'
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
         dotnet-version: 9.x
 
     - name: Setup GO
       if: inputs.install-go == 'true'
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: 1.25
 
     - name: Setup Rust
       if: inputs.install-rust == 'true'
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
       with:
         # Disable this action's built-in cache; callers that care about
         # caching should use `Swatinem/rust-cache` in their workflow,

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,5 @@ updates:
        update-types:
          - "patch"
          - "minor"
+   cooldown:
+     default-days: 7

--- a/.github/workflows/_rust-tool-check.yml
+++ b/.github/workflows/_rust-tool-check.yml
@@ -72,7 +72,7 @@ jobs:
       # to set unconditionally (unused by crates.io-only builds).
       CARGO_REGISTRIES_AIO_SDKS_TOKEN: ${{ secrets.aio-sdks-token }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Refuse to fall back to `stable` silently. Every caller must
       # either pin via a `rust-toolchain.toml` in `path`, or point
@@ -90,7 +90,7 @@ jobs:
           fi
 
       - name: Setup Rust (from rust-toolchain.toml)
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           # Tell the action where to look for `rust-toolchain.toml`.
           # Without this it would only check the repo root, find no
@@ -106,7 +106,7 @@ jobs:
         run: bash ./rust/scripts/system-deps.sh
 
       - name: Cache cargo build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: ${{ inputs.path }}
           shared-key: tool-${{ inputs.name }}
@@ -114,7 +114,7 @@ jobs:
       # Install cargo subcommands AFTER the cache restore. `Swatinem/rust-cache`
       # caches `~/.cargo/bin`, so a warm cache makes this a no-op.
       - name: Install cargo tooling
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
         with:
           tool: cargo-hack,cargo-machete
 

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -38,12 +38,12 @@ jobs:
           echo "dotnet_tag=$dotnet_tag" >> $GITHUB_OUTPUT
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 9.x
 
       - name: Checkout Main
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: main
 
@@ -53,7 +53,7 @@ jobs:
           cp main/.github/pages/index.html _site
 
       - name: Checkout Dotnet
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{steps.tags.outputs.dotnet_tag}}
           path: dotnet
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload to GitHub Pages
         id: upload
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
 
   deploy:
     permissions:
@@ -83,5 +83,5 @@ jobs:
     steps:
       - name: Deploy artifact
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
  

--- a/.github/workflows/cd-go.yml
+++ b/.github/workflows/cd-go.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
         fetch-tags: true

--- a/.github/workflows/ci-connector-schema.yml
+++ b/.github/workflows/ci-connector-schema.yml
@@ -23,19 +23,19 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Download connector metadata schema
       run: wget https://json.schemastore.org/aio-connector-metadata-11.0-preview.json -O ./connector-metadata-schema.json
 
     - name: Validate JSON with Glob
-      uses: nhalstead/validate-json-action@v0.1.12
+      uses: nhalstead/validate-json-action@c0708aeeffcbd850efc50b0c4597efdf6aaf0ee3 # v0.1.12
       with:
         schema: ./connector-metadata-schema.json
         jsons: ./doc/akri_connector/example-connector-metadata.json,./doc/akri_connector/minimal-example-connector-metadata.json
 
     - name: Validate JSON with Glob
-      uses: nhalstead/validate-json-action@v0.1.12
+      uses: nhalstead/validate-json-action@c0708aeeffcbd850efc50b0c4597efdf6aaf0ee3 # v0.1.12
       with:
         schema: ./connector-metadata-schema.json
         jsons: ./dotnet/samples/Connectors/EventDrivenTcpThermostatConnector/connector-metadata.json,./dotnet/samples/Connectors/SqlConnector/connector-metadata.json,./dotnet/samples/Connectors/PollingRestThermostatConnector/connector-metadata.json,./dotnet/samples/Connectors/ManagementActionConnector/connector-metadata.json

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 45
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Install AIO
       uses: ./.github/actions/configure-aio
@@ -47,7 +47,7 @@ jobs:
       run: dotnet --info
 
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
+      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -272,7 +272,7 @@ jobs:
       run: dotnet test dotnet/Azure.Iot.Operations.sln --filter "FullyQualifiedName~Azure.Iot.Operations.Services.IntegrationTest.LeaderElectionClientIntegrationTests.TestFencing" -e MQTT_TEST_BROKER_CS="HostName=127.0.0.1;TcpPort=8883;UseTls=true;ClientId=TestClient;CaFile=${{ env.CA_FILE_PATH }};KeyFile=${{ env.CLIENT_KEY }};CertFile=${{ env.CLIENT_CERT }}" --logger:"trx;LogFileName=test-results.trx" -- xunit.parallelizeAssembly=true    
 
     - name: Azure.Iot.Operations.Mqtt.UnitTests Package Code Coverage
-      uses: irongut/CodeCoverageSummary@v1.3.0
+      uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
       if: always()
       with:
         filename: ./**/Azure.Iot.Operations.Mqtt.UnitTests/TestResults/*/coverage.cobertura.xml
@@ -283,7 +283,7 @@ jobs:
         output: both
 
     - name: Azure.Iot.Operations.Mqtt.IntegrationTests Package Code Coverage
-      uses: irongut/CodeCoverageSummary@v1.3.0
+      uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
       if: always()
       with:
         filename: ./**/Azure.Iot.Operations.Mqtt.IntegrationTests/TestResults/*/coverage.cobertura.xml
@@ -294,7 +294,7 @@ jobs:
         output: both
 
     - name: Azure.Iot.Operations.Protocol.UnitTests Code Coverage
-      uses: irongut/CodeCoverageSummary@v1.3.0
+      uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
       if: always()
       with:
         filename: ./**/Azure.Iot.Operations.Protocol.UnitTests/TestResults/*/coverage.cobertura.xml
@@ -305,7 +305,7 @@ jobs:
         output: both
         
     - name: Azure.Iot.Operations.Protocol.IntegrationTests Code Coverage
-      uses: irongut/CodeCoverageSummary@v1.3.0
+      uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
       if: always()
       with:
         filename: ./**/Azure.Iot.Operations.Protocol.IntegrationTests/TestResults/*/coverage.cobertura.xml
@@ -316,7 +316,7 @@ jobs:
         output: both
 
     - name: Azure.Iot.Operations.Protocol.MetlTests Code Coverage
-      uses: irongut/CodeCoverageSummary@v1.3.0
+      uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
       if: always()
       with:
         filename: ./**/Azure.Iot.Operations.Protocol.MetlTests/TestResults/*/coverage.cobertura.xml
@@ -327,7 +327,7 @@ jobs:
         output: both
 
     - name: Azure.Iot.Operations.Services.UnitTests Code Coverage
-      uses: irongut/CodeCoverageSummary@v1.3.0
+      uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
       if: always()
       with:
         filename: ./**/Azure.Iot.Operations.Services.UnitTests/TestResults/*/coverage.cobertura.xml
@@ -338,7 +338,7 @@ jobs:
         output: both
 
     - name: Azure.Iot.Operations.Services.IntegrationTests Code Coverage
-      uses: irongut/CodeCoverageSummary@v1.3.0
+      uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
       if: always()
       with:
         filename: ./**/Azure.Iot.Operations.Services.IntegrationTests/TestResults/*/coverage.cobertura.xml
@@ -349,7 +349,7 @@ jobs:
         output: both
 
     - name: Azure.Iot.Operations.Connector.UnitTests Code Coverage
-      uses: irongut/CodeCoverageSummary@v1.3.0
+      uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
       if: always()
       with:
         filename: ./**/Azure.Iot.Operations.Connector.UnitTests/TestResults/*/coverage.cobertura.xml
@@ -359,7 +359,7 @@ jobs:
         indicators: true
         output: both
 
-    - uses: dorny/test-reporter@v3
+    - uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
       id: test-reporter
       if: always()
       with:

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Install AIO
       uses: ./.github/actions/configure-aio
@@ -90,35 +90,35 @@ jobs:
       run: RUNNER_TRACKING_ID="" && dotnet run --project eng/test/faultablemqttbroker/src/Azure.Iot.Operations.FaultableMqttBroker/Azure.Iot.Operations.FaultableMqttBroker.csproj &
 
     - name: Verify Go protocol module
-      uses: magefile/mage-action@v4
+      uses: magefile/mage-action@a662bd8c29d8106879588cfff83b2faf6e6f59db # v4.0.0
       with:
         version: latest
         args: civerify
         workdir: ./go/protocol
 
     - name: Verify Go mqtt module
-      uses: magefile/mage-action@v4
+      uses: magefile/mage-action@a662bd8c29d8106879588cfff83b2faf6e6f59db # v4.0.0
       with:
         version: latest
         args: civerify
         workdir: ./go/mqtt
 
     - name: Verify Go services module
-      uses: magefile/mage-action@v4
+      uses: magefile/mage-action@a662bd8c29d8106879588cfff83b2faf6e6f59db # v4.0.0
       with:
         version: latest
         args: civerify
         workdir: ./go/services
 
     - name: Verify Go protocol tests
-      uses: magefile/mage-action@v4
+      uses: magefile/mage-action@a662bd8c29d8106879588cfff83b2faf6e6f59db # v4.0.0
       with:
         version: latest
         args: civerify
         workdir: ./go/test/protocol
 
     - name: Verify Go integration tests
-      uses: magefile/mage-action@v4
+      uses: magefile/mage-action@a662bd8c29d8106879588cfff83b2faf6e6f59db # v4.0.0
       with:
         version: latest
         args: civerify

--- a/.github/workflows/ci-markdown.yml
+++ b/.github/workflows/ci-markdown.yml
@@ -16,10 +16,10 @@ jobs:
     name: CI-spelling
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Spell check
-        uses: streetsidesoftware/cspell-action@v8
+        uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
         continue-on-error: true
         with:
           files: "**/*"
@@ -32,7 +32,7 @@ jobs:
     name: CI-links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # On PRs, detect whether the link-check config or workflow itself was
       # modified. If so, we want a full-repo scan (nofilter) instead of the
@@ -41,7 +41,7 @@ jobs:
       - name: Detect linkspector config changes
         if: github.event_name == 'pull_request'
         id: changes
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         with:
           filters: |
             config:
@@ -68,7 +68,7 @@ jobs:
         run: npx --yes @puppeteer/browsers install "chrome@${CHROME_VERSION}" --path "$HOME/.cache/puppeteer"
 
       - name: Run linkspector
-        uses: umbrelladocs/action-linkspector@v1
+        uses: umbrelladocs/action-linkspector@568ec8d29fa92b31fd9ea5381e155c51e922af83 # v1.5.5
         with:
           config_file: .github/.linkspector.yml
           fail_on_error: true

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -46,10 +46,10 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Rust (pinned via rust-toolchain.toml)
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           # Disable this action's built-in cache; `Swatinem/rust-cache`
           # (below) handles caching for us and also caches `target/`,
@@ -57,7 +57,7 @@ jobs:
           cache: false
 
       - name: Setup .NET (for codegen drift check)
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 9.x
 
@@ -65,7 +65,7 @@ jobs:
         run: bash ./scripts/system-deps.sh
 
       - name: Cache cargo build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: rust
           shared-key: check
@@ -75,7 +75,7 @@ jobs:
       # makes this step a no-op. Running it before the cache restore would
       # risk the restore clobbering the just-installed binary.
       - name: Install cargo tooling
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
         with:
           tool: cargo-machete,cargo-hack
 
@@ -112,7 +112,7 @@ jobs:
         rust: ["1.88", "stable"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install AIO
         uses: ./.github/actions/configure-aio
@@ -131,7 +131,7 @@ jobs:
         run: bash ./scripts/system-deps.sh
 
       - name: Cache cargo build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: rust
           shared-key: tests-${{ matrix.rust }}
@@ -160,7 +160,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install AIO
         uses: ./.github/actions/configure-aio
@@ -174,7 +174,7 @@ jobs:
         run: bash ./scripts/system-deps.sh
 
       - name: Cache cargo build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: rust
           # Distinct from the `tests` keys: instrumented builds produce
@@ -183,7 +183,7 @@ jobs:
 
       # See `check` job above for why this step lives after the cache.
       - name: Install cargo tooling
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
         with:
           tool: cargo-llvm-cov
 
@@ -197,7 +197,7 @@ jobs:
           VERBOSE: "1"
         run: make coverage
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: report-azure-iot-operations
           path: ${{ runner.temp }}/report

--- a/.github/workflows/ci-wot-codegen.yml
+++ b/.github/workflows/ci-wot-codegen.yml
@@ -29,10 +29,10 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 10.0.x
 
@@ -45,7 +45,7 @@ jobs:
       - name: Test
         run: dotnet test -c Debug wot-codegen/codegen.sln --no-build --logger "trx;LogFileName=test-results.trx"
 
-      - uses: dorny/test-reporter@v3
+      - uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         id: test-reporter
         if: always()
         with:

--- a/.github/workflows/e2e-cross-language.yml
+++ b/.github/workflows/e2e-cross-language.yml
@@ -37,7 +37,7 @@ jobs:
       COUNTER_SERVER_ID: ${{ matrix.server }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       #=======================================================================
       # Install prerequisites

--- a/.github/workflows/run-codegen.yml
+++ b/.github/workflows/run-codegen.yml
@@ -11,10 +11,10 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -22,12 +22,12 @@ jobs:
         run: (pushd /; dotnet tool install --global Apache.Avro.Tools; popd) # need to install from root to avoid using the nuget.config we for build and push
     
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 8.0.301
           
       - name: Setup .NET 9
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 9.0.200
       

--- a/.github/workflows/run-docgen.yml
+++ b/.github/workflows/run-docgen.yml
@@ -12,15 +12,15 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 8.0.301
           
       - name: Setup .NET 9
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 9.0.200
       

--- a/.github/workflows/verify-docgen.yml
+++ b/.github/workflows/verify-docgen.yml
@@ -20,15 +20,15 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 8.0.301
           
       - name: Setup .NET 9
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 9.0.200
       


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
