### PR TITLE
[Rust][Services][Connector] Bump versions for 09-02-2026 beta releases

### DIFF
--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_connector"
-version = "2.1.1"
+version = "2.2.0-beta1"
 edition = "2024"
 rust-version.workspace = true
 license = "MIT"
@@ -14,8 +14,8 @@ publish = true
 
 [dependencies]
 azure_iot_operations_protocol = { version = "1.0", path = "../azure_iot_operations_protocol" }
-azure_iot_operations_services = { version = "1.4.0-beta2", path = "../azure_iot_operations_services", features = ["state_store", "edge_registry", "schema_registry", "azure_device_registry"]  }
-azure_iot_operations_mqtt = { version = "1.1", path = "../azure_iot_operations_mqtt" }
+azure_iot_operations_services = { version = "1.4.0-beta3", path = "../azure_iot_operations_services", features = ["state_store", "edge_registry", "schema_registry", "azure_device_registry"]  }
+azure_iot_operations_mqtt = { version = "1.2", path = "../azure_iot_operations_mqtt" }
 chrono = { workspace = true, features = ["clock"] }
 derive_builder.workspace = true
 derive-getters.workspace = true

--- a/rust/azure_iot_operations_services/Cargo.toml
+++ b/rust/azure_iot_operations_services/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_services"
-version = "1.4.0-beta2"
+version = "1.4.0-beta3"
 edition = "2024"
 rust-version.workspace = true
 license = "MIT"
@@ -57,7 +57,7 @@ azure_device_registry = [
 
 [dependencies]
 azure_iot_operations_protocol = { version = "1.0", path = "../azure_iot_operations_protocol" }
-azure_iot_operations_mqtt = { version = "1.1", path = "../azure_iot_operations_mqtt" }
+azure_iot_operations_mqtt = { version = "1.2", path = "../azure_iot_operations_mqtt" }
 bytes = { workspace = true, optional = true }
 derive_builder.workspace = true
 log.workspace = true

--- a/rust/sample_applications/sample_connector_scaffolding/Cargo.toml
+++ b/rust/sample_applications/sample_connector_scaffolding/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2024"
 publish = false
 
 [dependencies]
-azure_iot_operations_connector = { version = "2.1", path = "../../azure_iot_operations_connector" }
-azure_iot_operations_services = { version = "1.4.0-beta2", path = "../../azure_iot_operations_services" }
+azure_iot_operations_connector = { version = "2.2.0-beta1", path = "../../azure_iot_operations_connector" }
+azure_iot_operations_services = { version = "1.4.0-beta3", path = "../../azure_iot_operations_services" }
 azure_iot_operations_protocol = { version = "1.1", path = "../../azure_iot_operations_protocol" }
 env_logger = "0.11.8"
 log = "0.4.21"


### PR DESCRIPTION
`azure_iot_operations_services`: `1.4.0-beta2` -> `1.4.0-beta3`
`azure_iot_operations_connector`: `2.1.1` -> `2.2.0-beta1`