### PR TITLE
[.NET] Allow aio-persistence on non-retained messages and stop queued publishes from hanging

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Mqtt/OrderedAckMqttClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Mqtt/OrderedAckMqttClient.cs
@@ -163,19 +163,21 @@ public class OrderedAckMqttClient : IMqttPubSubClient, IMqttClient
     }
 
     /// <summary>
-    /// Validate the size of the message before sending it to the MQTT broker.
+    /// Validate that the provided message can be sent to the MQTT broker.
     /// </summary>
     /// <param name="message">The message to validate.</param>
     /// <exception cref="InvalidOperationException">If the message size is too large.</exception>
     /// <remarks>
+    /// The outcome of this check depends only on the contents of the message, so a message that fails it can never
+    /// be sent successfully no matter how many times it is retried. Clients that queue messages should run this
+    /// check before queueing so that an invalid message fails immediately instead of waiting in the queue forever.
     /// </remarks>
-    private Task ValidateMessageSize(MqttApplicationMessage message)
+    protected void ValidateOutgoingMessage(MqttApplicationMessage message)
     {
         if (_maximumPacketSize > 0 && message.Payload.Length > _maximumPacketSize)
         {
             throw new InvalidOperationException($"Message size is too large. Maximum message size is {_maximumPacketSize} bytes.");
         }
-        return Task.CompletedTask;
     }
 
     /// <inheritdoc/>
@@ -184,12 +186,7 @@ public class OrderedAckMqttClient : IMqttPubSubClient, IMqttClient
         cancellationToken.ThrowIfCancellationRequested();
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        if (applicationMessage.AioPersistence && !applicationMessage.Retain)
-        {
-            throw new InvalidOperationException("Only retained messages can be persisted. Must set the retain flag on this message to persist it.");
-        }
-
-        await ValidateMessageSize(applicationMessage);
+        ValidateOutgoingMessage(applicationMessage);
         return MqttNetConverter.ToGeneric(await UnderlyingMqttClient.PublishAsync(MqttNetConverter.FromGeneric(applicationMessage), cancellationToken));
     }
 

--- a/dotnet/src/Azure.Iot.Operations.Mqtt/Session/MqttSessionClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Mqtt/Session/MqttSessionClient.cs
@@ -202,6 +202,10 @@ namespace Azure.Iot.Operations.Mqtt.Session
                 throw new SessionClosedException("Cannot publish until the session has been re-opened. The session is closed either because it could not be recovered or because this client was manually closed.");
             }
 
+            // Validate before queueing. A message that fails this check can never be published, so queueing it
+            // would leave the caller waiting on a request that is guaranteed to never complete.
+            ValidateOutgoingMessage(applicationMessage);
+
             TaskCompletionSource<MqttClientPublishResult> tcs = new TaskCompletionSource<MqttClientPublishResult>();
 
             var queuedRequest = new QueuedPublishRequest(applicationMessage, tcs, cancellationToken: cancellationToken);
@@ -692,6 +696,24 @@ namespace Azure.Iot.Operations.Mqtt.Session
 
         private async Task ExecuteSinglePublishAsync(QueuedPublishRequest queuedPublish, CancellationToken cancellationToken)
         {
+            try
+            {
+                // The outcome of this check depends only on the message itself, so a message that fails it can
+                // never be published no matter how often it is retried. Complete the request now instead of
+                // leaving it queued for a retry that is guaranteed to fail in exactly the same way.
+                ValidateOutgoingMessage(queuedPublish.Request);
+            }
+            catch (Exception validationException)
+            {
+                await _outgoingRequestList.RemoveAsync(queuedPublish, CancellationToken.None);
+                if (!queuedPublish.ResultTaskCompletionSource.TrySetException(validationException))
+                {
+                    Trace.TraceError("Failed to set task completion source for publish request");
+                }
+
+                return;
+            }
+
             try
             {
                 MqttClientPublishResult publishResult = await base.PublishAsync(queuedPublish.Request, cancellationToken);

--- a/dotnet/src/Azure.Iot.Operations.Protocol/Models/MqttApplicationMessage.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/Models/MqttApplicationMessage.cs
@@ -145,11 +145,17 @@ namespace Azure.Iot.Operations.Protocol.Models
         public List<MqttUserProperty>? UserProperties { get; set; }
 
         /// <summary>
-        /// If set, this message will be persisted by the AIO MQTT broker. This is only applicable
-        /// for retained messages. If this value is set to true, <see cref="Retain"/> must also be set to true.
+        /// If set, this message asks the AIO MQTT broker to persist the data associated with it to disk.
         /// </summary>
         /// <remarks>
-        /// This feature is only applicable with the AIO MQTT broker.
+        /// This feature is only applicable with the AIO MQTT broker, and only takes effect when the broker is
+        /// deployed with persistence enabled and configured to allow dynamic persistence requests.
+        /// <para>
+        /// The broker applies this flag to whichever kind of data the message produces. Setting it together with
+        /// <see cref="Retain"/> asks the broker to persist the retained message, while setting it on a request to a
+        /// service that writes to the broker's state store asks the broker to persist the resulting state store
+        /// entries. It is therefore valid on messages that are not retained.
+        /// </para>
         /// </remarks>
         public bool AioPersistence
         {
@@ -166,6 +172,7 @@ namespace Azure.Iot.Operations.Protocol.Models
             set
             {
                 UserProperties ??= new();
+                UserProperties.RemoveAll(property => property.Name.Equals(AioPersistenceFlag, StringComparison.Ordinal));
                 UserProperties.Add(new(AioPersistenceFlag, value ? "true" : "false"));
             }
         }

--- a/dotnet/src/Azure.Iot.Operations.Protocol/Models/MqttClientOptions.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/Models/MqttClientOptions.cs
@@ -337,7 +337,8 @@ namespace Azure.Iot.Operations.Protocol.Models
         /// If true, the session used in this connection will be persisted by the AIO MQTT broker.
         /// </summary>
         /// <remarks>
-        /// This feature is only applicable with the AIO MQTT broker.
+        /// This feature is only applicable with the AIO MQTT broker, and only takes effect when the broker is
+        /// deployed with persistence enabled and configured to allow dynamic persistence requests.
         /// </remarks>
         public bool AioPersistence
         {
@@ -354,6 +355,7 @@ namespace Azure.Iot.Operations.Protocol.Models
             set
             {
                 UserProperties ??= new();
+                UserProperties.RemoveAll(property => property.Name.Equals(AioPersistenceFlag, StringComparison.Ordinal));
                 UserProperties.Add(new(AioPersistenceFlag, value ? "true" : "false"));
             }
         }

--- a/dotnet/src/Azure.Iot.Operations.Protocol/RPC/CommandInvoker.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/RPC/CommandInvoker.cs
@@ -602,7 +602,10 @@ namespace Azure.Iot.Operations.Protocol.RPC
 
                 try
                 {
-                    MqttClientPublishResult pubAck = await _mqttClient.PublishAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+                    // Bound the publish by the command timeout. The session client queues publishes and only
+                    // completes them once they reach the broker, so without this an unsendable request would
+                    // block here forever and the command timeout below would never be reached.
+                    MqttClientPublishResult pubAck = await WallClock.WaitAsync(_mqttClient.PublishAsync(requestMessage, cancellationToken), reifiedCommandTimeout, cancellationToken).ConfigureAwait(false);
                     MqttClientPublishReasonCode pubReasonCode = pubAck.ReasonCode;
                     if (pubReasonCode != MqttClientPublishReasonCode.Success)
                     {
@@ -616,6 +619,21 @@ namespace Azure.Iot.Operations.Protocol.RPC
                         };
                     }
                     Trace.TraceInformation($"Invoked command '{_commandName}' with correlation ID {requestGuid} to topic '{requestTopic}'");
+                }
+                catch (TimeoutException ex)
+                {
+                    SetCanceledSafe(responsePromise.CompletionSource);
+
+                    throw new AkriMqttException($"Command '{_commandName}' timed out while publishing the request", ex)
+                    {
+                        Kind = AkriMqttErrorKind.Timeout,
+                        IsShallow = false,
+                        IsRemote = false,
+                        TimeoutName = nameof(commandTimeout),
+                        TimeoutValue = reifiedCommandTimeout,
+                        CommandName = _commandName,
+                        CorrelationId = requestGuid,
+                    };
                 }
                 catch (Exception ex) when (ex is not AkriMqttException)
                 {

--- a/dotnet/src/Azure.Iot.Operations.Protocol/RPC/CommandInvoker.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/RPC/CommandInvoker.cs
@@ -600,12 +600,17 @@ namespace Azure.Iot.Operations.Protocol.RPC
 
                 await SubscribeAsNeededAsync(responseTopicFilter, cancellationToken).ConfigureAwait(false);
 
+                // Bound the publish by the command timeout. The session client queues publishes and only completes
+                // them once they reach the broker, so without this an unsendable request would block here forever
+                // and the command timeout below would never be reached. The timeout is also linked into the token
+                // handed to the publish so that a client which queues requests discards this one instead of
+                // sending it once the connection recovers.
+                using CancellationTokenSource publishTimeoutCts = WallClock.CreateCancellationTokenSource(reifiedCommandTimeout);
+                using CancellationTokenSource publishCts = CancellationTokenSource.CreateLinkedTokenSource(publishTimeoutCts.Token, cancellationToken);
+
                 try
                 {
-                    // Bound the publish by the command timeout. The session client queues publishes and only
-                    // completes them once they reach the broker, so without this an unsendable request would
-                    // block here forever and the command timeout below would never be reached.
-                    MqttClientPublishResult pubAck = await WallClock.WaitAsync(_mqttClient.PublishAsync(requestMessage, cancellationToken), reifiedCommandTimeout, cancellationToken).ConfigureAwait(false);
+                    MqttClientPublishResult pubAck = await WallClock.WaitAsync(_mqttClient.PublishAsync(requestMessage, publishCts.Token), reifiedCommandTimeout, cancellationToken).ConfigureAwait(false);
                     MqttClientPublishReasonCode pubReasonCode = pubAck.ReasonCode;
                     if (pubReasonCode != MqttClientPublishReasonCode.Success)
                     {
@@ -620,8 +625,12 @@ namespace Azure.Iot.Operations.Protocol.RPC
                     }
                     Trace.TraceInformation($"Invoked command '{_commandName}' with correlation ID {requestGuid} to topic '{requestTopic}'");
                 }
-                catch (TimeoutException ex)
+                catch (Exception ex) when ((ex is TimeoutException || ex is OperationCanceledException) && !cancellationToken.IsCancellationRequested)
                 {
+                    // Cancel explicitly in case the wait timed out before the linked token did, so that a queued
+                    // publish is always dropped rather than delivered after this invocation has given up.
+                    await publishCts.CancelAsync().ConfigureAwait(false);
+
                     SetCanceledSafe(responsePromise.CompletionSource);
 
                     throw new AkriMqttException($"Command '{_commandName}' timed out while publishing the request", ex)

--- a/dotnet/src/Azure.Iot.Operations.Protocol/Telemetry/OutgoingTelemetryMetadata.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/Telemetry/OutgoingTelemetryMetadata.cs
@@ -27,11 +27,12 @@ namespace Azure.Iot.Operations.Protocol.Telemetry
         public CloudEvent? CloudEvent { get; set; }
 
         /// <summary>
-        /// If true, this telemetry will be persisted by the AIO MQTT broker upon receiving it. This is only applicable
-        /// for retained messages. If this value is set to true, <see cref="Retain"/> must also be set to true.
+        /// If true, this telemetry asks the AIO MQTT broker to persist it to disk upon receiving it. This is only
+        /// applicable for retained messages, so <see cref="Retain"/> should also be set to true.
         /// </summary>
         /// <remarks>
-        /// This feature is only applicable with the AIO MQTT broker.
+        /// This feature is only applicable with the AIO MQTT broker, and only takes effect when the broker is
+        /// deployed with persistence enabled and configured to allow dynamic persistence requests.
         /// </remarks>
         public bool PersistTelemetry { get; set; }
 

--- a/dotnet/src/Azure.Iot.Operations.Services/StateStore/StateStoreClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/StateStore/StateStoreClient.cs
@@ -26,6 +26,15 @@ namespace Azure.Iot.Operations.Services.StateStore
 
         internal const string FencingTokenUserPropertyKey = AkriSystemProperties.ReservedPrefix + "ft";
 
+        /// <summary>
+        /// The user property that asks the broker to persist the state store entries written by this request.
+        /// </summary>
+        /// <remarks>
+        /// This is sent on a normal (non-retained) request/response message. The broker applies the flag to the
+        /// state store entries the request produces, not to the request message itself.
+        /// </remarks>
+        internal const string PersistUserPropertyKey = "aio-persistence";
+
         public event Func<object?, KeyChangeMessageReceivedEventArgs, Task>? KeyChangeMessageReceivedAsync;
 
         public StateStoreClient(ApplicationContext applicationContext, IMqttPubSubClient mqttClient)
@@ -188,7 +197,7 @@ namespace Azure.Iot.Operations.Services.StateStore
             CommandRequestMetadata requestMetadata = new CommandRequestMetadata();
             if (options.PersistEntry)
             {
-                requestMetadata.UserData.TryAdd("aio-persistence", "true");
+                requestMetadata.UserData.TryAdd(PersistUserPropertyKey, "true");
             }
 
             if (options.FencingToken != null)

--- a/dotnet/test/Azure.Iot.Operations.Mqtt.UnitTests/Session/MqttSessionClientTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Mqtt.UnitTests/Session/MqttSessionClientTests.cs
@@ -2454,6 +2454,98 @@ namespace Azure.Iot.Operations.Protocol.Session.UnitTests
             Assert.True(containsFlag);
         }
 
+        [Fact(Timeout = 30000)]
+        public async Task MqttSessionClient_PublishWithPersistenceAndWithoutRetain()
+        {
+            // The "aio-persistence" user property is not exclusive to retained messages. The AIO broker also
+            // accepts it on ordinary request/response messages to persist the state store entries they produce,
+            // which is how the state store and Edge Registry clients request durable writes. Rejecting the
+            // property on non-retained messages left those requests stuck in the outgoing queue forever.
+            using MockMqttClient mockMqttClient = new MockMqttClient();
+            await using MqttSessionClient sessionClient = new(mockMqttClient);
+
+            mockMqttClient.OnConnectAttempt += (actualConnect) =>
+            {
+                return Task.FromResult(MQTTnet.MqttClientConnectResultFactory.Create(MockMqttClient.SuccessfulInitialConnAck, MQTTnet.Formatter.MqttProtocolVersion.V500));
+            };
+
+            await sessionClient.ConnectAsync(new MqttClientOptions(new MqttClientTcpOptions("localhost", 1883))
+            {
+                SessionExpiryInterval = 100,
+            });
+
+            TaskCompletionSource<MQTTnet.MqttApplicationMessage> actualPublishTcs = new();
+            mockMqttClient.OnPublishAttempt += (actualPublish) =>
+            {
+                actualPublishTcs.TrySetResult(actualPublish);
+                return Task.FromResult(new MQTTnet.MqttClientPublishResult(0, MQTTnet.MqttClientPublishReasonCode.Success, "", new List<MQTTnet.Packets.MqttUserProperty>()));
+            };
+
+            MqttApplicationMessage publish = new("someTopic")
+            {
+                AioPersistence = true,
+                Retain = false,
+            };
+
+            MqttClientPublishResult publishResult = await sessionClient.PublishAsync(publish).WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Equal(MqttClientPublishReasonCode.Success, publishResult.ReasonCode);
+
+            var actualPublish = await actualPublishTcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+            Assert.False(actualPublish.Retain);
+            Assert.Contains(
+                actualPublish.UserProperties,
+                property => property.Name.Equals("aio-persistence") && property.ReadValueAsString().Equals("true"));
+        }
+
+        [Fact(Timeout = 30000)]
+        public async Task MqttSessionClient_QueuedPublishThatFailsValidationCompletesInsteadOfHanging()
+        {
+            // A queued request is only ever retried when the connection is recovered, so a request that fails a
+            // check depending solely on the message would otherwise sit in the queue forever and its caller would
+            // wait on a result that never arrives.
+            using MockMqttClient mockMqttClient = new MockMqttClient();
+            await using MqttSessionClient sessionClient = new(mockMqttClient);
+
+            mockMqttClient.OnConnectAttempt += (actualConnect) =>
+            {
+                return Task.FromResult(MQTTnet.MqttClientConnectResultFactory.Create(MockMqttClient.SuccessfulInitialConnAck, MQTTnet.Formatter.MqttProtocolVersion.V500));
+            };
+
+            // Queue the publish before connecting so that the maximum packet size isn't known yet and the request
+            // can't be rejected up front.
+            Task<MqttClientPublishResult> publishTask = sessionClient.PublishAsync(
+                new MqttApplicationMessage("someTopic") { PayloadSegment = new byte[64] });
+
+            await sessionClient.ConnectAsync(new MqttClientOptions(new MqttClientTcpOptions("localhost", 1883))
+            {
+                SessionExpiryInterval = 100,
+                MaximumPacketSize = 8,
+            });
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await publishTask.WaitAsync(TimeSpan.FromSeconds(10)));
+        }
+
+        [Fact(Timeout = 30000)]
+        public async Task MqttSessionClient_PublishThatFailsValidationThrowsBeforeBeingQueued()
+        {
+            using MockMqttClient mockMqttClient = new MockMqttClient();
+            await using MqttSessionClient sessionClient = new(mockMqttClient);
+
+            mockMqttClient.OnConnectAttempt += (actualConnect) =>
+            {
+                return Task.FromResult(MQTTnet.MqttClientConnectResultFactory.Create(MockMqttClient.SuccessfulInitialConnAck, MQTTnet.Formatter.MqttProtocolVersion.V500));
+            };
+
+            await sessionClient.ConnectAsync(new MqttClientOptions(new MqttClientTcpOptions("localhost", 1883))
+            {
+                SessionExpiryInterval = 100,
+                MaximumPacketSize = 8,
+            });
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await sessionClient.PublishAsync(new MqttApplicationMessage("someTopic") { PayloadSegment = new byte[64] }));
+        }
+
         [Fact(Timeout = 10000)] // Adding a timeout to this test in case some deadlock causes disposing the session client when it is reconnecting to hang
         public async Task MqttSessionClient_DisposeWhileReconnectingStopsReconnectingAndDoesNotThrow() // check for the issue reported in https://github.com/Azure/iot-operations-sdks/issues/1281
         {

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/CommandInvokerTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/CommandInvokerTests.cs
@@ -397,6 +397,10 @@ namespace Azure.Iot.Operations.Protocol.UnitTests
             Assert.False(ex.IsRemote);
             Assert.Equal("myCmd", ex.CommandName);
             Assert.Equal(TimeSpan.FromSeconds(1), ex.TimeoutValue);
+
+            // The publish must also be cancelled, otherwise a client that queues requests could still deliver
+            // this one after the invoker has given up, causing a late command execution.
+            Assert.True(mock.LastPublishCancellationToken.IsCancellationRequested);
         }
 
         [Fact]

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/CommandInvokerTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/CommandInvokerTests.cs
@@ -369,6 +369,36 @@ namespace Azure.Iot.Operations.Protocol.UnitTests
             Assert.Equal(numberOfRequests - 1, responses.Count);
         }
 
+        [Fact(Timeout = 30000)]
+        public async Task InvokerTimesOutWhenPublishNeverCompletes()
+        {
+            // The session client queues publishes and only completes them once they reach the broker, so a request
+            // that can never be sent must still surface the command timeout instead of waiting forever.
+            ApplicationContext applicationContext = new ApplicationContext();
+            var mock = new MockMqttPubSubClient("mockClient");
+            await using var invoker = new InvokerStub(applicationContext, mock)
+            {
+                RequestTopicPattern = "command/{executorId}/mockCommand",
+                ResponseTopicPrefix = "clients/mockClient",
+            };
+
+            CommandRequestMetadata requestMetadata = new();
+            requestMetadata.UserData["_stallPublish"] = "true";
+
+            var invokeRequest = invoker.InvokeCommandAsync(
+                "req Payload",
+                requestMetadata,
+                additionalTopicTokenMap: new Dictionary<string, string> { { "executorId", "someExecutor" } },
+                commandTimeout: TimeSpan.FromSeconds(1));
+
+            var ex = await Assert.ThrowsAsync<AkriMqttException>(() => invokeRequest);
+            Assert.Equal(AkriMqttErrorKind.Timeout, ex.Kind);
+            Assert.False(ex.IsShallow);
+            Assert.False(ex.IsRemote);
+            Assert.Equal("myCmd", ex.CommandName);
+            Assert.Equal(TimeSpan.FromSeconds(1), ex.TimeoutValue);
+        }
+
         [Fact]
         public async Task InvokerDisconnectsBeforePuback()
         {

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/MockMqttPubSubClient.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/MockMqttPubSubClient.cs
@@ -37,6 +37,9 @@ namespace Azure.Iot.Operations.Protocol.UnitTests
 
         public List<MqttApplicationMessage> MessagesPublished { get; } = new();
 
+        /// <summary>The cancellation token handed to the most recent publish, so tests can assert it gets cancelled.</summary>
+        public CancellationToken LastPublishCancellationToken { get; private set; }
+
         public string SubscribedTopicReceived { get; set; }
 
         public string UnsubscribeTopicReceived { get; set; }
@@ -177,6 +180,7 @@ namespace Azure.Iot.Operations.Protocol.UnitTests
         {
             MessagePublished = applicationMessage;
             MessagesPublished.Add(applicationMessage);
+            LastPublishCancellationToken = cancellationToken;
             Interlocked.Increment(ref _numPublishes);
 
             if (applicationMessage.CorrelationData != null)

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/MockMqttPubSubClient.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/MockMqttPubSubClient.cs
@@ -205,6 +205,13 @@ namespace Azure.Iot.Operations.Protocol.UnitTests
                 throw new MqttCommunicationException("PubAck dropped");
             }
 
+            if (applicationMessage.UserProperties!.TryGetProperty("_stallPublish", out string? stallPublish) && stallPublish == "true")
+            {
+                // Simulates a session client that has queued the publish but can never actually send it, so the
+                // returned task never completes.
+                return new TaskCompletionSource<MqttClientPublishResult>().Task;
+            }
+
             string topic = applicationMessage.Topic;
             if (topic.Contains("failPubAck"))
             {


### PR DESCRIPTION
## Problem

Every Edge Registry create hung forever with `Persist=true` (reported against `CreateSchemaVersionAsync`). This is why #1477 was rolled back in #1489.

The same hang is live on `main` today, independently of Edge Registry:

- `StateStoreClient.SetAsync(PersistEntry: true)` — broken since #909
- `TelemetrySender` with `PersistTelemetry = true` and `Retain = false`
- Any publish exceeding the negotiated maximum packet size

## Root cause

Two independent defects: one made the request fail, the other made it hang instead of reporting the failure.

### 1. The retain-only guard was too narrow

`OrderedAckMqttClient.PublishAsync` rejected any message carrying `aio-persistence` unless the message was also retained:

```csharp
if (applicationMessage.AioPersistence && !applicationMessage.Retain)
{
    throw new InvalidOperationException("Only retained messages can be persisted. ...");
}
```

Per the [broker persistence documentation](https://learn.microsoft.com/en-us/azure/iot-operations/manage-mqtt-broker/howto-broker-persistence), `aio-persistence` is a **single broker-level user-property key**, configured once globally, that clients use to request persistence for **three** kinds of data:

| Data type | Where the client sets it | Retain involved? |
|---|---|---|
| Retained messages | PUBLISH with `retain=1` | Yes, inherently |
| Subscriber queues | CONNECT packet | No |
| **State store entries** | **a normal QoS-1 request** | **No** |

> "Clients can request persistence for their data by sending an MQTT v5 user property in their messages. This lets clients dynamically enable persistence for their messages, subscriber queues, or state store entries."

Edge Registry and DSS writes are the third row, so the guard enforced a precondition that belongs to only one of three effects. Neither the Go SDK (`go/services/statestore/set.go` sets it on a non-retained RPC) nor the Rust SDK has an equivalent restriction — Rust explicitly marks `Persist` as *not* user-restricted.

Worth noting: #909, which introduced the guard, documented DSS usage **without** retain in its own description:

```csharp
StateStoreSetRequestOptions setOptions = new() { PersistEntry = true };
await stateStoreClient.SetAsync("someKey", "someValue", setOptions);
```

So that path was broken on arrival. #1477 only made persistence the default and therefore made it visible.

### 2. The failure hung instead of surfacing

`MqttSessionClient.PublishAsync` queues the request and awaits a `TaskCompletionSource` with no timeout. In the worker:

- `IsFatal` did not classify the validation error, so the non-fatal branch **silently discarded it** — no removal, no `TrySetException`, not even a trace log.
- The request stayed marked `IsInFlight = true`, and `PeekNextUnsentAsync` skips in-flight requests, so it was never retried and its TCS was never completed.
- `CommandInvoker` awaited the publish **outside** its `WallClock.WaitAsync(..., commandTimeout)` wrapper, so the command timeout could not end the wait either.

Result: the caller waited forever and the RPC timeout never fired — matching the report exactly.

## Why not add a `Retain` flag to `CommandRequestMetadata`?

@timtay-microsoft suggested that approach in [this review comment](https://github.com/Azure/iot-operations-sdks/pull/1477#discussion_r3929799540). I went a different way, because retaining an RPC *request* is unsafe:

- **Replay / duplicate execution.** `CommandExecutor.SubscribeAsync` builds its topic filter without setting `RetainHandling`, which defaults to `SendAtSubscribe (0)`. Every executor restart would be re-delivered the stale retained create request, carrying a dead correlation ID and a response topic nobody is listening on.
- **Permanent topic pollution.** A retained message survives until someone publishes a zero-byte retained message to that exact topic. Nothing in the SDK ever does that.
- **Cross-language divergence.** .NET would become the only SDK publishing retained RPC requests, breaking parity with Go and Rust and with the METL cross-language cases.
- **It isn't what makes the write durable.** State store persistence comes from the property reaching the state store subsystem; `retain` would only add an unrelated retained message on the request topic.

Retain is designed for *state* (last-known value for late subscribers). RPC requests are *events* — meaningful once. Removing the false precondition also covers Tim's [follow-up](https://github.com/Azure/iot-operations-sdks/pull/1477#discussion_r3929804380) about extending the fix to the DSS client and telemetry sender, in a single change and without per-call-site plumbing.

## Changes

- **Remove the retain-only restriction** and correct the XML docs on `AioPersistence` / `PersistTelemetry` to describe all three effects and the broker configuration they depend on.
- **Validate outgoing messages before queueing**, and again in the worker before sending, so a message that can never be published completes its caller exceptionally instead of being swallowed. This also fixes the identical pre-existing hang for oversized messages.
- **Bound the RPC publish by the command timeout** in `CommandInvoker`, mapping a stall to `AkriMqttErrorKind.Timeout` rather than an indefinite wait.
- **Fix the `AioPersistence` setter**, which appended instead of replacing. Because `TryGetProperty` returns the first match, setting it back to `false` still read as `true` and two contradictory properties went on the wire.

Retry-on-reconnect semantics for genuinely transient failures are deliberately unchanged — an earlier attempt to fail all non-fatal errors broke `CommandInvokerPubAckDroppedByDisconnection_Reconnect`, so the fix is scoped to deterministic validation failures only.

## Testing

Four regression tests, each verified to fail without the corresponding fix:

- `MqttSessionClient_PublishWithPersistenceAndWithoutRetain` — the reported scenario. Previously hung; existing coverage missed it because every prior test paired `AioPersistence` with `Retain = true`.
- `MqttSessionClient_QueuedPublishThatFailsValidationCompletesInsteadOfHanging`
- `MqttSessionClient_PublishThatFailsValidationThrowsBeforeBeingQueued`
- `InvokerTimesOutWhenPublishNeverCompletes` — **hung indefinitely** without the invoker fix, so it carries an explicit timeout.

| Suite | Result |
|---|---|
| `Azure.Iot.Operations.Mqtt.UnitTests` | 168 passed |
| `Azure.Iot.Operations.Protocol.UnitTests` | 287 passed |
| `Azure.Iot.Operations.Protocol.MetlTests` | 346 passed |
| `Azure.Iot.Operations.Services.UnitTests` | 212 passed |

Build clean at 0 warnings (`TreatWarningsAsErrors` enabled).

## Follow-up

With this in place, #1477 can be re-landed as-is — its `Persist=true` default works against the fixed MQTT layer. The Rust equivalent (#1474) needs no change, since Rust never had the guard.
