### PR TITLE
[.NET] Re-add persistence support for edge registry client, fix bug around not setting retain flag on persisted messages

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Protocol/RPC/CommandInvoker.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/RPC/CommandInvoker.cs
@@ -551,6 +551,14 @@ namespace Azure.Iot.Operations.Protocol.RPC
                     MessageExpiryInterval = (uint)reifiedCommandTimeout.TotalSeconds,
                 };
 
+                if (metadata != null && metadata.PersistCommand)
+                {
+                    // Only set this value if it is true since sending "aio-persistence":"false"
+                    // is the same as not sending "aio-persistence" user property at all
+                    requestMessage.AioPersistence = true;
+                    requestMessage.Retain = true;
+                }
+
                 string? clientId = _mqttClient.ClientId;
                 if (string.IsNullOrEmpty(clientId))
                 {

--- a/dotnet/src/Azure.Iot.Operations.Protocol/RPC/CommandRequestMetadata.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/RPC/CommandRequestMetadata.cs
@@ -82,6 +82,11 @@ namespace Azure.Iot.Operations.Protocol.RPC
         public ExtendedCloudEvent? ExtendedCloudEvent { get; internal set; }
 
         /// <summary>
+        /// The flag whether this command request will be persisted using the AIO-specific persistence mechanism or not. Only works for AIO MQTT broker.
+        /// </summary>
+        public bool PersistCommand { get; set; }
+
+        /// <summary>
         /// Construct CommandRequestMetadata in user code, for passing to a command invocation.
         /// </summary>
         /// <remarks>

--- a/dotnet/src/Azure.Iot.Operations.Protocol/RPC/CommandRequestMetadata.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/RPC/CommandRequestMetadata.cs
@@ -82,7 +82,7 @@ namespace Azure.Iot.Operations.Protocol.RPC
         public ExtendedCloudEvent? ExtendedCloudEvent { get; internal set; }
 
         /// <summary>
-        /// The flag whether this command request will be persisted using the AIO-specific persistence mechanism or not. Only works for AIO MQTT broker.
+        /// Indicates whether this command request should be persisted using the AIO-specific persistence mechanism. Only supported by the AIO MQTT broker.
         /// </summary>
         public bool PersistCommand { get; set; }
 

--- a/dotnet/src/Azure.Iot.Operations.Protocol/Telemetry/TelemetrySender.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/Telemetry/TelemetrySender.cs
@@ -147,6 +147,7 @@ namespace Azure.Iot.Operations.Protocol.Telemetry
                     // Only set this value if it is true since sending "aio-persistence":"false"
                     // is the same as not sending "aio-persistence" user property at all
                     applicationMessage.AioPersistence = true;
+                    applicationMessage.Retain = true;
                 }
 
                 // If the cloud event subject has not been set by the user, provide the default value

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/CreateOptions.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/CreateOptions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Iot.Operations.Services.EdgeRegistry;
+
+/// <summary>
+/// Options that control the behavior of a create operation.
+/// </summary>
+public class CreateOptions
+{
+    /// <summary>
+    /// Whether the Edge Registry should persist the created entity to disk. Defaults to <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// Persistence requires a broker deployed with persistence enabled; it is otherwise ignored. An
+    /// entity that has been persisted can't later be made non-persistent.
+    /// </remarks>
+    public bool Persist { get; set; } = true;
+}

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.Core.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.Core.cs
@@ -43,7 +43,7 @@ public sealed partial class EdgeRegistryClient : ICoreClient
     }
 
     /// <inheritdoc/>
-    public async Task<Models.CoreGroupEntity> CreateGroupAsync(string groupType, GroupId groupId, Models.CoreGroupAttributes attributes, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    public async Task<Models.CoreGroupEntity> CreateGroupAsync(string groupType, GroupId groupId, Models.CoreGroupAttributes attributes, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -53,6 +53,7 @@ public sealed partial class EdgeRegistryClient : ICoreClient
 
         var output = await _coreStub.CreateGroupAsync(
             request,
+            PersistenceMetadata(options),
             additionalTopicTokenMap: GroupTopicTokens(groupType),
             commandTimeout: timeout ?? s_defaultCommandTimeout,
             cancellationToken: cancellationToken);
@@ -95,7 +96,7 @@ public sealed partial class EdgeRegistryClient : ICoreClient
     }
 
     /// <inheritdoc/>
-    public async Task<Models.CoreResourceEntity> CreateResourceAsync(string groupType, GroupId groupId, string resourceType, string resourceId, Models.CoreResourceMetaAttributes meta, Dictionary<string, byte[]> resourceExtensions, CreateVersionId defaultVersionId, Models.CoreVersionAttributes defaultVersion, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    public async Task<Models.CoreResourceEntity> CreateResourceAsync(string groupType, GroupId groupId, string resourceType, string resourceId, Models.CoreResourceMetaAttributes meta, Dictionary<string, byte[]> resourceExtensions, CreateVersionId defaultVersionId, Models.CoreVersionAttributes defaultVersion, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -111,6 +112,7 @@ public sealed partial class EdgeRegistryClient : ICoreClient
 
         var output = await _coreStub.CreateResourceAsync(
             request,
+            PersistenceMetadata(options),
             additionalTopicTokenMap: ResourceTopicTokens(groupType, resourceType, resourceId),
             commandTimeout: timeout ?? s_defaultCommandTimeout,
             cancellationToken: cancellationToken);
@@ -181,7 +183,7 @@ public sealed partial class EdgeRegistryClient : ICoreClient
     }
 
     /// <inheritdoc/>
-    public async Task<Models.CoreVersionEntity> CreateVersionAsync(string groupType, GroupId groupId, string resourceType, string resourceId, IReadOnlyList<Models.Label> resourceLabels, CreateVersionId versionId, Models.CoreVersionAttributes version, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    public async Task<Models.CoreVersionEntity> CreateVersionAsync(string groupType, GroupId groupId, string resourceType, string resourceId, IReadOnlyList<Models.Label> resourceLabels, CreateVersionId versionId, Models.CoreVersionAttributes version, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -196,6 +198,7 @@ public sealed partial class EdgeRegistryClient : ICoreClient
 
         var output = await _coreStub.CreateVersionAsync(
             request,
+            PersistenceMetadata(options),
             additionalTopicTokenMap: ResourceTopicTokens(groupType, resourceType, resourceId),
             commandTimeout: timeout ?? s_defaultCommandTimeout,
             cancellationToken: cancellationToken);

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.Schema.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.Schema.cs
@@ -10,7 +10,7 @@ namespace Azure.Iot.Operations.Services.EdgeRegistry;
 public sealed partial class EdgeRegistryClient : ISchemaRegistryClient
 {
     /// <inheritdoc/>
-    public async Task<Models.SchemaVersion> CreateSchemaVersionAsync(GroupId groupId, string schemaId, IReadOnlyList<Models.Label> schemaLabels, Models.SchemaVersionAttributes version, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    public async Task<Models.SchemaVersion> CreateSchemaVersionAsync(GroupId groupId, string schemaId, IReadOnlyList<Models.Label> schemaLabels, Models.SchemaVersionAttributes version, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -19,6 +19,7 @@ public sealed partial class EdgeRegistryClient : ISchemaRegistryClient
 
         var output = await _schemaStub.CreateSchemaVersionAsync(
             request,
+            PersistenceMetadata(options),
             additionalTopicTokenMap: ExtensionResourceTopicTokens(SchemaIdTopicToken, schemaId),
             commandTimeout: timeout ?? s_defaultCommandTimeout,
             cancellationToken: cancellationToken);

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.ThingDescription.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.ThingDescription.cs
@@ -11,7 +11,7 @@ namespace Azure.Iot.Operations.Services.EdgeRegistry;
 public sealed partial class EdgeRegistryClient : IThingDescriptionClient
 {
     /// <inheritdoc/>
-    public async Task<Models.ThingDescriptionVersion> CreateThingDescriptionVersionAsync(GroupId groupId, string thingDescriptionId, IReadOnlyList<Models.Label> thingDescriptionLabels, Models.ThingDescriptionVersionAttributes version, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    public async Task<Models.ThingDescriptionVersion> CreateThingDescriptionVersionAsync(GroupId groupId, string thingDescriptionId, IReadOnlyList<Models.Label> thingDescriptionLabels, Models.ThingDescriptionVersionAttributes version, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -20,6 +20,7 @@ public sealed partial class EdgeRegistryClient : IThingDescriptionClient
 
         var output = await _thingDescriptionStub.CreateThingDescriptionVersionAsync(
             request,
+            PersistenceMetadata(options),
             additionalTopicTokenMap: ExtensionResourceTopicTokens(ThingDescriptionIdTopicToken, thingDescriptionId),
             commandTimeout: timeout ?? s_defaultCommandTimeout,
             cancellationToken: cancellationToken);

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.ThingModel.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.ThingModel.cs
@@ -10,7 +10,7 @@ namespace Azure.Iot.Operations.Services.EdgeRegistry;
 public sealed partial class EdgeRegistryClient : IThingModelClient
 {
     /// <inheritdoc/>
-    public async Task<Models.ThingModelVersion> CreateThingModelVersionAsync(GroupId groupId, string thingModelId, IReadOnlyList<Models.Label> thingModelLabels, Models.ThingModelVersionAttributes version, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    public async Task<Models.ThingModelVersion> CreateThingModelVersionAsync(GroupId groupId, string thingModelId, IReadOnlyList<Models.Label> thingModelLabels, Models.ThingModelVersionAttributes version, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -19,6 +19,7 @@ public sealed partial class EdgeRegistryClient : IThingModelClient
 
         var output = await _thingModelStub.CreateThingModelVersionAsync(
             request,
+            PersistenceMetadata(options),
             additionalTopicTokenMap: ExtensionResourceTopicTokens(ThingModelIdTopicToken, thingModelId),
             commandTimeout: timeout ?? s_defaultCommandTimeout,
             cancellationToken: cancellationToken);

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.cs
@@ -4,7 +4,6 @@
 using System.Globalization;
 using Azure.Iot.Operations.Protocol;
 using Azure.Iot.Operations.Protocol.RPC;
-using Microsoft.VisualBasic;
 
 namespace Azure.Iot.Operations.Services.EdgeRegistry;
 

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.cs
@@ -3,6 +3,8 @@
 
 using System.Globalization;
 using Azure.Iot.Operations.Protocol;
+using Azure.Iot.Operations.Protocol.RPC;
+using Microsoft.VisualBasic;
 
 namespace Azure.Iot.Operations.Services.EdgeRegistry;
 
@@ -85,6 +87,20 @@ public sealed partial class EdgeRegistryClient : IEdgeRegistryClient
         Dictionary<string, string> tokens = ExtensionResourceTopicTokens(resourceIdToken, resourceId);
         tokens[VersionIdTopicToken] = versionId.ToString(CultureInfo.InvariantCulture);
         return tokens;
+    }
+
+    /// <summary>Builds the request metadata for a create request, signalling persistence when requested.</summary>
+    private static CommandRequestMetadata PersistenceMetadata(CreateOptions? options)
+    {
+        CommandRequestMetadata requestMetadata = new();
+
+        // Only sent when true, since sending "false" is equivalent to omitting the property.
+        if (options is null || options.Persist)
+        {
+            requestMetadata.PersistCommand = true;
+        }
+
+        return requestMetadata;
     }
 
     /// <inheritdoc/>

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/ICoreClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/ICoreClient.cs
@@ -60,10 +60,11 @@ public interface ICoreClient : IAsyncDisposable
     /// <param name="groupType">The Group type (the xRegistry Group collection name).</param>
     /// <param name="groupId">The Group. Use <see cref="GroupId.CloudDefault"/> for the cloud-default Group (the configured namespace).</param>
     /// <param name="attributes">The attributes of the Group to create.</param>
+    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, the created entity is persisted.</param>
     /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task whose result is the created <see cref="Models.CoreGroupEntity"/>.</returns>
-    Task<Models.CoreGroupEntity> CreateGroupAsync(string groupType, GroupId groupId, Models.CoreGroupAttributes attributes, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+    Task<Models.CoreGroupEntity> CreateGroupAsync(string groupType, GroupId groupId, Models.CoreGroupAttributes attributes, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 
     /// <summary>Deletes a Group. Deletes cascade to all contained Resources and their Versions.</summary>
     /// <param name="groupType">The Group type (the xRegistry Group collection name).</param>
@@ -95,10 +96,11 @@ public interface ICoreClient : IAsyncDisposable
     /// <param name="resourceExtensions">Resource-level extension attributes, keyed by extension name.</param>
     /// <param name="defaultVersionId">The Version id to assign to the Resource's default Version. Use <see cref="CreateVersionId.ServerAssigned"/> to let the service choose.</param>
     /// <param name="defaultVersion">The attributes of the Resource's default Version.</param>
+    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, the created entity is persisted.</param>
     /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task whose result is the created <see cref="Models.CoreResourceEntity"/>.</returns>
-    Task<Models.CoreResourceEntity> CreateResourceAsync(string groupType, GroupId groupId, string resourceType, string resourceId, Models.CoreResourceMetaAttributes meta, Dictionary<string, byte[]> resourceExtensions, CreateVersionId defaultVersionId, Models.CoreVersionAttributes defaultVersion, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+    Task<Models.CoreResourceEntity> CreateResourceAsync(string groupType, GroupId groupId, string resourceType, string resourceId, Models.CoreResourceMetaAttributes meta, Dictionary<string, byte[]> resourceExtensions, CreateVersionId defaultVersionId, Models.CoreVersionAttributes defaultVersion, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 
     /// <summary>Lists the XIDs of Resources matching the query, optionally filtered by Resource type and/or a single label.</summary>
     /// <param name="groups">The Groups to search; see <see cref="GroupQuery"/> for the available scopes.</param>
@@ -141,10 +143,11 @@ public interface ICoreClient : IAsyncDisposable
     /// <param name="resourceLabels">Labels applied to the parent Resource.</param>
     /// <param name="versionId">The Version id to assign. Use <see cref="CreateVersionId.ServerAssigned"/> to let the service choose.</param>
     /// <param name="version">The attributes of the Version to create.</param>
+    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, the created entity is persisted.</param>
     /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task whose result is the created <see cref="Models.CoreVersionEntity"/>.</returns>
-    Task<Models.CoreVersionEntity> CreateVersionAsync(string groupType, GroupId groupId, string resourceType, string resourceId, IReadOnlyList<Models.Label> resourceLabels, CreateVersionId versionId, Models.CoreVersionAttributes version, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+    Task<Models.CoreVersionEntity> CreateVersionAsync(string groupType, GroupId groupId, string resourceType, string resourceId, IReadOnlyList<Models.Label> resourceLabels, CreateVersionId versionId, Models.CoreVersionAttributes version, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 
     /// <summary>Lists the XIDs of Versions matching the query, optionally filtered by Resource type, Resource id, and/or a single label.</summary>
     /// <param name="groups">The Groups to search; see <see cref="GroupQuery"/> for the available scopes.</param>

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/ISchemaRegistryClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/ISchemaRegistryClient.cs
@@ -30,10 +30,11 @@ public interface ISchemaRegistryClient
     /// <param name="schemaId">The Schema (Resource) identifier.</param>
     /// <param name="schemaLabels">Labels applied to the parent Schema.</param>
     /// <param name="version">The attributes of the Schema Version to create.</param>
+    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, the created entity is persisted.</param>
     /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task whose result is the created <see cref="Models.SchemaVersion"/>.</returns>
-    Task<Models.SchemaVersion> CreateSchemaVersionAsync(GroupId groupId, string schemaId, IReadOnlyList<Models.Label> schemaLabels, Models.SchemaVersionAttributes version, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+    Task<Models.SchemaVersion> CreateSchemaVersionAsync(GroupId groupId, string schemaId, IReadOnlyList<Models.Label> schemaLabels, Models.SchemaVersionAttributes version, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 
     /// <summary>Retrieves a Schema Version.</summary>
     /// <param name="groupId">The Schema Group. Use <see cref="GroupId.CloudDefault"/> for the cloud-default Group (the configured namespace).</param>

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/IThingDescriptionClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/IThingDescriptionClient.cs
@@ -31,10 +31,11 @@ public interface IThingDescriptionClient
     /// <param name="thingDescriptionId">The Thing Description (Resource) identifier.</param>
     /// <param name="thingDescriptionLabels">Labels applied to the parent Thing Description.</param>
     /// <param name="version">The attributes of the Thing Description Version to create.</param>
+    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, the created entity is persisted.</param>
     /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task whose result is the created <see cref="Models.ThingDescriptionVersion"/>.</returns>
-    Task<Models.ThingDescriptionVersion> CreateThingDescriptionVersionAsync(GroupId groupId, string thingDescriptionId, IReadOnlyList<Models.Label> thingDescriptionLabels, Models.ThingDescriptionVersionAttributes version, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+    Task<Models.ThingDescriptionVersion> CreateThingDescriptionVersionAsync(GroupId groupId, string thingDescriptionId, IReadOnlyList<Models.Label> thingDescriptionLabels, Models.ThingDescriptionVersionAttributes version, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 
     /// <summary>Retrieves a Thing Description Version.</summary>
     /// <param name="groupId">The Thing Description Group. Use <see cref="GroupId.CloudDefault"/> for the cloud-default Group (the configured namespace).</param>

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/IThingModelClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/IThingModelClient.cs
@@ -31,10 +31,11 @@ public interface IThingModelClient
     /// <param name="thingModelId">The Thing Model (Resource) identifier.</param>
     /// <param name="thingModelLabels">Labels applied to the parent Thing Model.</param>
     /// <param name="version">The attributes of the Thing Model Version to create.</param>
+    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, the created entity is persisted.</param>
     /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task whose result is the created <see cref="Models.ThingModelVersion"/>.</returns>
-    Task<Models.ThingModelVersion> CreateThingModelVersionAsync(GroupId groupId, string thingModelId, IReadOnlyList<Models.Label> thingModelLabels, Models.ThingModelVersionAttributes version, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+    Task<Models.ThingModelVersion> CreateThingModelVersionAsync(GroupId groupId, string thingModelId, IReadOnlyList<Models.Label> thingModelLabels, Models.ThingModelVersionAttributes version, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 
     /// <summary>Retrieves a Thing Model Version.</summary>
     /// <param name="groupId">The Thing Model Group. Use <see cref="GroupId.CloudDefault"/> for the cloud-default Group (the configured namespace).</param>

--- a/dotnet/src/Azure.Iot.Operations.Services/StateStore/StateStoreClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/StateStore/StateStoreClient.cs
@@ -188,7 +188,7 @@ namespace Azure.Iot.Operations.Services.StateStore
             CommandRequestMetadata requestMetadata = new CommandRequestMetadata();
             if (options.PersistEntry)
             {
-                requestMetadata.UserData.TryAdd("aio-persistence", "true");
+                requestMetadata.PersistCommand = true;
             }
 
             if (options.FencingToken != null)

--- a/dotnet/test/Azure.Iot.Operations.Services.UnitTests/StateStore/StateStoreClientTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Services.UnitTests/StateStore/StateStoreClientTests.cs
@@ -153,7 +153,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore
                 .Setup(
                     mock => mock.InvokeAsync(
                         It.Is<byte[]>(array => array != null && Enumerable.SequenceEqual(array, expectedServiceRequestPayload)),
-                        It.Is<CommandRequestMetadata>(metadata => metadata.UserData.ContainsKey("aio-persistence")),
+                        It.Is<CommandRequestMetadata>(metadata => metadata.PersistCommand),
                         It.IsAny<Dictionary<string, string>>(),
                         expectedRequestTimeout,
                         cancellationToken))
@@ -173,7 +173,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore
             mockStateStoreGeneratedClient.Verify(
                     mock => mock.InvokeAsync(
                         It.Is<byte[]>(array => array != null && Enumerable.SequenceEqual(array, expectedServiceRequestPayload)),
-                        It.Is<CommandRequestMetadata>(metadata => metadata.UserData.ContainsKey("aio-persistence")),
+                        It.Is<CommandRequestMetadata>(metadata => metadata.PersistCommand),
                         null,
                         expectedRequestTimeout,
                         cancellationToken),


### PR DESCRIPTION
#1477 but with a necessary bug fix for the case where a command or telemetry sets the aio-persistence flag. 

The main issue hidden in the original PR was that the AIO MQTT broker would reject any publish with the "aio-persistence" user property flag set, but without the publish's retain flag set. As a result, our session client would fail to deliver these kinds of messages (and would retry indefinitely)

Now, when the command request/outgoing telemetry metadata objects will use the "PersistCommand"/"PersistTelemetry" flag to communicate to the command invoker/telemetry sender to set both the "aio-persistence" user property and the retain flag on the corresponding MQTT publish packet. This addresses the first part of the issue described above. 

Fixing the session client to not retry on cases like the above will be a separate fix.