### PR TITLE
[.NET][Protocol] Fix bug where RpcCallAsync did not throw until timeout

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Protocol/RPC/RpcCallAsync.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/RPC/RpcCallAsync.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 
 namespace Azure.Iot.Operations.Protocol.RPC
@@ -23,17 +21,13 @@ namespace Azure.Iot.Operations.Protocol.RPC
 
         public TaskAwaiter<TResp> GetAwaiter()
         {
-            return ExtendedAsync
-            .ContinueWith(
-                (exTask) =>
-                {
-                    if (exTask.IsFaulted)
-                    {
-                        Debug.Assert(exTask.Exception?.InnerException != null);
-                        ExceptionDispatchInfo.Capture(exTask.Exception?.InnerException!).Throw();
-                    }
-                    return exTask.Result.Response;
-                }).GetAwaiter();
+            return GetResponseAsync().GetAwaiter();
+        }
+
+        private async Task<TResp> GetResponseAsync()
+        {
+            ExtendedResponse<TResp> extendedResponse = await ExtendedAsync.ConfigureAwait(false);
+            return extendedResponse.Response;
         }
     }
 }

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/RpcCallAsyncTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/RpcCallAsyncTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Iot.Operations.Protocol.RPC;
+
+namespace Azure.Iot.Operations.Protocol.UnitTests;
+
+public class RpcCallAsyncTests
+{
+    [Fact]
+    public async Task AwaitReturnsResponse()
+    {
+        var expectedResponse = new TestResponse();
+        RpcCallAsync<TestResponse> rpcCall = new(
+            Task.FromResult(new ExtendedResponse<TestResponse> { Response = expectedResponse }),
+            Guid.NewGuid());
+
+        TestResponse actualResponse = await rpcCall;
+
+        Assert.Same(expectedResponse, actualResponse);
+    }
+
+    [Fact]
+    public async Task AwaitPreservesOriginalException()
+    {
+        var expectedException = new InvalidOperationException("Expected failure");
+        RpcCallAsync<TestResponse> rpcCall = new(
+            Task.FromException<ExtendedResponse<TestResponse>>(expectedException),
+            Guid.NewGuid());
+
+        InvalidOperationException actualException =
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await rpcCall);
+
+        Assert.Same(expectedException, actualException);
+    }
+
+    [Fact]
+    public async Task AwaitPreservesCancellation()
+    {
+        using CancellationTokenSource cancellationTokenSource = new();
+        cancellationTokenSource.Cancel();
+        RpcCallAsync<TestResponse> rpcCall = new(
+            Task.FromCanceled<ExtendedResponse<TestResponse>>(cancellationTokenSource.Token),
+            Guid.NewGuid());
+
+        OperationCanceledException exception =
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await rpcCall);
+
+        Assert.Equal(cancellationTokenSource.Token, exception.CancellationToken);
+    }
+
+    private sealed class TestResponse
+    {
+    }
+}

--- a/tools/deployment/initialize-cluster.sh
+++ b/tools/deployment/initialize-cluster.sh
@@ -15,6 +15,26 @@ help()
     echo
 }
 
+apt-get-update-with-retry()
+{
+    local max_attempts=3
+    local attempt
+
+    for attempt in $(seq 1 $max_attempts); do
+        if sudo apt-get update; then
+            return 0
+        fi
+
+        if [[ $attempt -lt $max_attempts ]]; then
+            sudo apt-get clean
+            sudo rm -rf /var/lib/apt/lists/*
+            sleep 5
+        fi
+    done
+
+    return 1
+}
+
 install-prerequisites()
 {
     echo
@@ -25,7 +45,7 @@ install-prerequisites()
 
     # install mosquitto
     if ! which mosquitto; then
-        sudo apt-get update
+        apt-get-update-with-retry
         sudo apt-get install -y --no-install-recommends mosquitto-clients
     fi
 
@@ -34,7 +54,7 @@ install-prerequisites()
     if ! [[ "$SYSTEM_NAME" == *"microsoft"* && "$SYSTEM_NAME" == *"WSL"* ]]; then
         if ! which docker;
         then
-            sudo apt-get update
+            apt-get-update-with-retry
             sudo apt-get install -y docker.io
         fi
     fi


### PR DESCRIPTION
If a call failed immediately, but the task was awaited with a timeout of 30 seconds, then the task would take 30 seconds to complete, throw an operation canceled exception with the real exception as the nested exception.

This caused our pipelines to stall at times like during runs with bugs like the one fixed in #1492