### PR TITLE
[.NET] Bump versions for 9/9/2026 release

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Protocol/Azure.Iot.Operations.Protocol.csproj
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/Azure.Iot.Operations.Protocol.csproj
@@ -7,7 +7,7 @@
     <LicenseUrl>https://github.com/Azure/iot-operations-sdks/blob/main/LICENSE</LicenseUrl>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <Authors>Microsoft</Authors>
-    <VersionPrefix>1.2.1</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <Nullable>enable</Nullable>
 		<AnalysisLevel>latest-recommended</AnalysisLevel>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/dotnet/src/Azure.Iot.Operations.Services/Azure.Iot.Operations.Services.csproj
+++ b/dotnet/src/Azure.Iot.Operations.Services/Azure.Iot.Operations.Services.csproj
@@ -7,7 +7,7 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <Authors>Microsoft</Authors>
     <VersionPrefix>1.3.0</VersionPrefix>
-    <VersionSuffix>beta3</VersionSuffix>
+    <VersionSuffix>beta4</VersionSuffix>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
 - Re-add persistence support for edge registry client, fix bug around not setting retain flag on persisted messages (#1494)
 - Fix bug where RpcCallAsync did not throw until timeout (#1495)